### PR TITLE
Explain --force a bit more clearly

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ FLAGS:
     -l, --long                   Show extended information
 
 OPTIONS:
-        --force <pattern>             Always include targeted crates matched by glob
+        --force <pattern>             Always include targeted crates matched by glob even when there are no changes
         --ignore-changes <pattern>    Ignore changes in files matched by glob
         --since <since>               Use this git reference instead of the last tag
 ```
@@ -166,7 +166,7 @@ FLAGS:
 
 OPTIONS:
         --allow-branch <pattern>            Specify which branches to allow from [default: master]
-        --force <pattern>                   Always include targeted crates matched by glob
+        --force <pattern>                   Always include targeted crates matched by glob even when there are no changes
         --git-remote <remote>               Push git changes to the specified remote [default: origin]
         --ignore-changes <pattern>          Ignore changes in files matched by glob
         --individual-tag-prefix <prefix>    Customize prefix for individual tags (should contain `%n`) [default: %n@]
@@ -217,7 +217,7 @@ FLAGS:
 
 OPTIONS:
         --allow-branch <pattern>            Specify which branches to allow from [default: master]
-        --force <pattern>                   Always include targeted crates matched by glob
+        --force <pattern>                   Always include targeted crates matched by glob even when there are no changes
         --git-remote <remote>               Push git changes to the specified remote [default: origin]
         --ignore-changes <pattern>          Ignore changes in files matched by glob
         --individual-tag-prefix <prefix>    Customize prefix for individual tags (should contain `%n`) [default: %n@]

--- a/cargo-workspaces/src/utils/changable.rs
+++ b/cargo-workspaces/src/utils/changable.rs
@@ -12,7 +12,7 @@ pub struct ChangeOpt {
     #[clap(long)]
     pub include_merged_tags: bool,
 
-    /// Always include targeted crates matched by glob
+    /// Always include targeted crates matched by glob even when there are no changes
     #[clap(long, value_name = "pattern")]
     pub force: Option<String>,
 


### PR DESCRIPTION
Hi, sorry for the noise on #34. May I suggest a small documentation improvement? Though the current document is well-written, I feel the intention is even clearer if it has some more words about `--force` is an option to use when we want to include the unchanged crates. Feel free to close if you think this is redundant :) Thanks!