### PR TITLE
Add `--registry` flag to publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ OPTIONS:
         --individual-tag-prefix <prefix>    Customize prefix for individual tags (should contain `%n`) [default: %n@]
     -m, --message <message>                 Use a custom commit message when creating the version commit
         --pre-id <identifier>               Specify prerelease identifier
+        --registry <registry>               Registry being published to
         --tag-prefix <prefix>               Customize tag prefix (can be empty) [default: v]
         --token <token>                     The token to use for publishing
 ```

--- a/cargo-workspaces/src/publish.rs
+++ b/cargo-workspaces/src/publish.rs
@@ -29,6 +29,10 @@ pub struct Publish {
     /// The token to use for publishing
     #[clap(long)]
     token: Option<String>,
+
+    /// Registry being published to
+    #[clap(long)]
+    registry: Option<String>,
 }
 
 impl Publish {
@@ -89,6 +93,11 @@ impl Publish {
             if let Some(ref token) = self.token {
                 args.push("--token");
                 args.push(token);
+            }
+
+            if let Some(ref registry) = self.registry {
+                args.push("--registry");
+                args.push(registry);
             }
 
             args.push("--manifest-path");


### PR DESCRIPTION
I tried to use this tool with my private registry but that requires the `--registry` flag, so I added it.