### PR TITLE
fix: update dependent crates if dependency is unversioned

### DIFF
--- a/cargo-workspaces/Cargo.toml
+++ b/cargo-workspaces/Cargo.toml
@@ -45,3 +45,8 @@ indoc = "1.0.3"
 
 [workspace.metadata.workspaces]
 no_individual_tags = true
+
+[patch.crates-io.dialoguer]
+# TODO! blocked awaiting crate update
+git = "https://github.com/mitsuhiko/dialoguer"
+rev = "f9c067bfe711d5a52cb6bac0c128d046d3ade594"

--- a/cargo-workspaces/src/create.rs
+++ b/cargo-workspaces/src/create.rs
@@ -69,7 +69,13 @@ impl Create {
 
         fs::write(
             &manifest,
-            change_versions(fs::read_to_string(&manifest)?, &name, &versions, false)?,
+            change_versions(
+                fs::read_to_string(&manifest)?,
+                &name,
+                &versions,
+                false,
+                false,
+            )?,
         )?;
 
         // TODO: If none of the globs in workspace `members` match, add a new entry

--- a/cargo-workspaces/src/utils/cargo.rs
+++ b/cargo-workspaces/src/utils/cargo.rs
@@ -432,7 +432,11 @@ pub fn change_versions(
                 }
                 None => {
                     if let Some(new_version) = versions.get(dep) {
-                        new_lines.push(format!("version = \"{}\"", new_version));
+                        if exact {
+                            new_lines.push(format!("version = \"={}\"", new_version));
+                        } else {
+                            new_lines.push(format!("version = \"{}\"", new_version));
+                        }
                     }
                 }
             }
@@ -789,6 +793,25 @@ mod test {
                 [dependencies]
                 this = { path = "../", version = "=0.3.0" } # hello"#
             }
+        );
+    }
+
+    #[test]
+    fn test_exact_dependency_table_version_missing() {
+        let m = indoc! {r#"
+            [dependencies.this]
+            path = "../" # hello
+        "#};
+
+        let mut v = Map::new();
+        v.insert("this".to_string(), Version::parse("0.3.0").unwrap());
+
+        assert_eq!(
+            change_versions(m.into(), "this", &v, true).unwrap(),
+            indoc! {r#"
+                [dependencies.this]
+                path = "../" # hello
+                version = "=0.3.0""#}
         );
     }
 

--- a/cargo-workspaces/src/utils/cargo.rs
+++ b/cargo-workspaces/src/utils/cargo.rs
@@ -331,9 +331,9 @@ pub fn rename_packages(
 
             Ok(())
         },
-        |line, pkg_name_line| {
+        |line, package_line| {
             if PACKAGE.is_match(line) {
-                pkg_name_line.replace(line.to_string());
+                package_line.replace(line.to_string());
             }
 
             Ok(None)

--- a/cargo-workspaces/src/utils/version.rs
+++ b/cargo-workspaces/src/utils/version.rs
@@ -262,7 +262,17 @@ impl VersionOpt {
                 .interact_on_opt(&TERM_ERR)?
             {
                 Some(2) | None => exit(0),
-                Some(1) => return Ok(()),
+                Some(1) => {
+                    if Confirm::with_theme(&ColorfulTheme::default())
+                        .with_prompt(
+                            "Are you sure you want this tool to auto-inject these versions?",
+                        )
+                        .default(false)
+                        .interact_on(&TERM_ERR)?
+                    {
+                        return Ok(());
+                    }
+                }
                 _ => {
                     let mut items = vec![];
                     for (name, deps) in pkgs.values() {

--- a/cargo-workspaces/src/utils/version.rs
+++ b/cargo-workspaces/src/utils/version.rs
@@ -117,6 +117,7 @@ impl VersionOpt {
                     if let Some(version) = new_versions.iter().find(|y| x.name == y.0).map(|y| &y.1)
                     {
                         !x.req.matches(version)
+                            || matches!(x.req.to_string().as_str(), "*" | ">=0.0.0")
                     } else {
                         false
                     }


### PR DESCRIPTION
Cargo interprets un-versioned dependencies (e.g `pkg = { path = "" }`) as having the version `>=0.0.0` | `*`. Going by the current logic, a dependent crate using that specification doesn't itself get updated.

This fixes that, ensuring it not only updates `pkg`'s version but also features injecting the version like the rest of the bumped packages. Ensuring consistency.

For clarity;

```toml
[dependencies]
pkg = { path = "./pkg" }
pkg = { path = "./pkg", version = "*" }
pkg = { path = "./pkg", version = ">=0.0.0" }

# all become

pkg = { path = "./pkg", version = "1.0.2" }
```

And

```toml
[dependencies.pkg]
path = "./pkg"

[dependencies.pkg]
path = "./pkg"
version = "*"

[dependencies.pkg]
path = "./pkg"
version = ">=0.0.0"

# all become

[dependencies.pkg]
path = "./pkg"
version = "1.0.2"
```

---

And, as a bonus, versioning now works when the package name in a table appears after the version

```toml
[dependencies.some_pkg]
path = "./pkg"
version = "0.0.1"
package = "pkg"

# now becomes

[dependencies.some_pkg]
path = "./pkg"
version = "0.3.0"
package = "pkg"
```