### PR TITLE
version: display crate version over group version in preview

### DIFF
--- a/cargo-workspaces/src/utils/version.rs
+++ b/cargo-workspaces/src/utils/version.rs
@@ -206,7 +206,7 @@ impl VersionOpt {
                 new_versions.push((
                     p.name.to_string(),
                     new_version.as_ref().expect(INTERNAL_ERR).clone(),
-                    cur_version.clone(),
+                    p.version.clone(),
                 ));
             }
         }


### PR DESCRIPTION
When confirming the versions in interactive mode, we should see the current crate version on the lhs instead of the current common version. Especially given that the current common version is already printed above and that independent packages show their individual versions.

```console
$ cargo ws version minor
info current common version 0.8.3
Changes:
 - foo: 0.8.3 => 0.9.0
 - bar: 0.1.2 => 0.9.0
 - baz: 0.2.7 => 0.3.0
```

instead of

```console
$ cargo ws version minor
info current common version 0.8.3
Changes:
 - foo: 0.8.3 => 0.9.0
 - bar: 0.8.3 => 0.9.0
 - baz: 0.2.7 => 0.3.0
```