### PR TITLE
Add support for running the create subcommand without prompts

### DIFF
--- a/cargo-workspaces/src/create.rs
+++ b/cargo-workspaces/src/create.rs
@@ -1,12 +1,33 @@
 use crate::utils::{cargo, change_versions, info, Error, Result, INTERNAL_ERR};
 
 use cargo_metadata::Metadata;
-use clap::Parser;
+use clap::{ArgEnum, Parser};
 use dialoguer::{theme::ColorfulTheme, Input, Select};
 use oclif::term::TERM_ERR;
 use semver::Version;
 
 use std::{collections::BTreeMap as Map, fs};
+
+#[derive(Debug, Clone, ArgEnum)]
+enum Edition {
+    #[clap(name = "2015")]
+    Fifteen,
+    #[clap(name = "2018")]
+    Eighteen,
+    #[clap(name = "2021")]
+    TwentyOne,
+}
+
+impl ToString for Edition {
+    fn to_string(&self) -> String {
+        match self {
+            Edition::Fifteen => "2015",
+            Edition::Eighteen => "2018",
+            Edition::TwentyOne => "2021",
+        }
+        .into()
+    }
+}
 
 /// Create a new workspace crate
 #[derive(Debug, Parser)]
@@ -15,15 +36,15 @@ pub struct Create {
     path: String,
 
     /// The crate edition, currently either 2015 or 2018
-    #[clap(long)]
-    edition: Option<String>,
+    #[clap(long, arg_enum)]
+    edition: Option<Edition>,
 
     /// Whether this is a binary crate
     #[clap(long, conflicts_with = "lib")]
     bin: bool,
 
     /// Whether this is a library crate
-    #[clap(long, conflicts_with = "bin")]
+    #[clap(long)]
     lib: bool,
 
     /// The name of the crate
@@ -36,61 +57,51 @@ impl Create {
         let theme = ColorfulTheme::default();
         let path = &metadata.workspace_root.join(&self.path);
 
-        let name:String =
-            match self.name.clone() {
-                Some(n) => n,
-                None => {
-                    Input::with_theme(&theme)
-                        .with_prompt("Name of the crate")
-                        .interact_on(&TERM_ERR)?
-                }
-            };
+        let name = match &self.name {
+            Some(n) => n.clone(),
+            None => Input::with_theme(&theme)
+                .with_prompt("Name of the crate")
+                .interact_on(&TERM_ERR)?,
+        };
 
         let types = vec!["library", "binary"];
 
-        let template =
-            if self.lib {
-                0
-            } else if self.bin {
-                1
-            } else {
-                Select::with_theme(&theme)
-                    .items(&types)
-                    .default(1)
-                    .with_prompt("Type of the crate")
-                    .interact_on(&TERM_ERR)?
-            };
+        let template = if self.lib {
+            0
+        } else if self.bin {
+            1
+        } else {
+            Select::with_theme(&theme)
+                .items(&types)
+                .default(1)
+                .with_prompt("Type of the crate")
+                .interact_on(&TERM_ERR)?
+        };
 
-        let editions = vec!["2015", "2018"];
+        let editions = Edition::value_variants()
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<_>>();
 
-        let edition =
-            match self.edition.clone() {
-                Some(edition) => match edition.as_str() {
-                    "2015" => 0,
-                    "2018" => 1,
-                    _ => {
-                        Select::with_theme(&theme)
-                            .items(&editions)
-                            .default(1)
-                            .with_prompt("Rust edition")
-                            .interact_on(&TERM_ERR)?
-                    }
-                },
-                None => {
-                    Select::with_theme(&theme)
-                        .items(&editions)
-                        .default(1)
-                        .with_prompt("Rust edition")
-                        .interact_on(&TERM_ERR)?
-                }
-            };
+        let edition = match &self.edition {
+            Some(edition) => match edition {
+                &Edition::Fifteen => 0,
+                &Edition::Eighteen => 1,
+                &Edition::TwentyOne => 2,
+            },
+            None => Select::with_theme(&theme)
+                .items(&editions)
+                .default(1)
+                .with_prompt("Rust edition")
+                .interact_on(&TERM_ERR)?,
+        };
 
         let mut args = vec![
             "new",
             "--name",
             name.as_str(),
             "--edition",
-            editions[edition],
+            editions[edition].as_str(),
         ];
 
         if template == 0 {

--- a/cargo-workspaces/tests/create.rs
+++ b/cargo-workspaces/tests/create.rs
@@ -1,0 +1,171 @@
+mod utils;
+use insta::assert_snapshot;
+use std::fs::{read_to_string, remove_dir, remove_file};
+use std::path::Path;
+
+/// Clean up a cargo or cargo-workspace created package directory
+/// This doesn't use remove_dir_all, so it's safer, but more liable to break
+/// if cargo new is updated in the future
+/// package_dir is the directory containing the package
+/// package_type is bin or lib
+fn clean_package_dir(package_dir: &String, package_type: &str) {
+    assert_ne!(package_dir, "");
+    assert_ne!(package_dir, "/");
+
+    let package_path = Path::new(package_dir);
+    let exists = package_path.exists();
+    if !exists {
+        return;
+    }
+
+    let cargo_fn = String::from(format!("{}/Cargo.toml", package_dir));
+    let cargo_path = Path::new(&cargo_fn);
+    let exists = cargo_path.exists();
+    if exists {
+        remove_file(cargo_fn).unwrap();
+    }
+
+    let src_fn =
+        match package_type {
+            "bin" => {
+                String::from(format!("{}/src/main.rs", package_dir))
+            },
+            "lib" => {
+                String::from(format!("{}/src/lib.rs", package_dir))
+            },
+            _ => {
+                return;
+            },
+        };
+
+    let src_path = Path::new(&src_fn);
+    let exists = src_path.exists();
+    if exists {
+        remove_file(src_fn).unwrap();
+    }
+
+    let src_fn = String::from(format!("{}/src", package_dir));
+    let src_path = Path::new(&src_fn);
+    let exists = src_path.exists();
+    if exists {
+        remove_dir(src_fn).unwrap();
+    }
+
+    let package_path = Path::new(package_dir);
+    let exists = package_path.exists();
+    if exists {
+        remove_dir(package_dir).unwrap();
+    }
+}
+
+/// Test creating a 2015 bin package
+#[test]
+fn test_create_bin_2015() {
+    let package_name = "mynewcrate-bin-2015";
+    let dir = "../fixtures/normal";
+    let package_dir = format!("{}/{}", dir, package_name);
+
+    clean_package_dir(&package_dir, "bin");
+
+    let _err = utils::run_err(dir,
+                              &["ws", "create", package_name,
+                                "--edition", "2015", "--bin",
+                                "--name", package_name]);
+
+    let manifest = read_to_string(format!("{}/Cargo.toml", package_dir)).unwrap();
+
+    assert_snapshot!(&manifest);
+
+    clean_package_dir(&package_dir, "bin");
+}
+
+/// Test creating a 2015 lib package
+#[test]
+fn test_create_lib_2015() {
+    let package_name = "mynewcrate-lib-2015";
+    let dir = "../fixtures/normal";
+    let package_dir = format!("{}/{}", dir, package_name);
+
+    clean_package_dir(&package_dir, "lib");
+
+    let _err = utils::run_err(dir,
+                              &["ws", "create", package_name,
+                                "--edition", "2015", "--lib",
+                                "--name", package_name]);
+
+    let manifest = read_to_string(format!("{}/Cargo.toml", package_dir)).unwrap();
+
+    assert_snapshot!(&manifest);
+
+    clean_package_dir(&package_dir, "lib");
+}
+
+/// Test creating a 2018 bin package
+#[test]
+fn test_create_bin_2018() {
+    let package_name = "mynewcrate-bin-2018";
+    let dir = "../fixtures/normal";
+    let package_dir = format!("{}/{}", dir, package_name);
+
+    clean_package_dir(&package_dir, "bin");
+
+    let _err = utils::run_err(dir,
+                              &["ws", "create", package_name,
+                                "--edition", "2018", "--bin",
+                                "--name", package_name]);
+
+    let manifest = read_to_string(format!("{}/Cargo.toml", package_dir)).unwrap();
+
+    assert_snapshot!(&manifest);
+
+    clean_package_dir(&package_dir, "bin");
+}
+
+/// Test creating a 2018 lib package
+#[test]
+fn test_create_lib_2018() {
+    let package_name = "mynewcrate-lib-2018";
+    let dir = "../fixtures/normal";
+    let package_dir = format!("{}/{}", dir, package_name);
+
+    clean_package_dir(&package_dir, "lib");
+
+    let _err = utils::run_err(dir,
+                              &["ws", "create", package_name,
+                                "--edition", "2018", "--lib",
+                                "--name", package_name]);
+
+    let manifest = read_to_string(format!("{}/Cargo.toml", package_dir)).unwrap();
+
+    assert_snapshot!(&manifest);
+
+    clean_package_dir(&package_dir, "lib");
+}
+
+/// Test that you can't create a library and binary package at the same time
+#[test]
+fn test_create_lib_and_bin_fails() {
+    let package_name = "mynewcrate-lib-and-bin-2018";
+    let dir = "../fixtures/normal";
+    let package_dir = format!("{}/{}", dir, package_name);
+
+    clean_package_dir(&package_dir, "lib");
+    clean_package_dir(&package_dir, "bin");
+
+    let err = utils::run_err(dir,
+                             &["ws", "create", package_name,
+                               "--edition", "2018", "--lib", "--bin",
+                               "--name", package_name]);
+
+    assert!(err.contains("error"));
+    assert!(err.contains("--bin"));
+    assert!(err.contains("cannot be used with"));
+    assert!(err.contains("--lib"));
+
+    let package_path = Path::new(&package_dir);
+    let exists = package_path.exists();
+    assert!(!exists);
+
+    clean_package_dir(&package_dir, "lib");
+    clean_package_dir(&package_dir, "bin");
+}

--- a/cargo-workspaces/tests/create.rs
+++ b/cargo-workspaces/tests/create.rs
@@ -8,53 +8,48 @@ use std::path::Path;
 /// if cargo new is updated in the future
 /// package_dir is the directory containing the package
 /// package_type is bin or lib
-fn clean_package_dir(package_dir: &String, package_type: &str) {
-    assert_ne!(package_dir, "");
-    assert_ne!(package_dir, "/");
+fn clean_package_dir(package_path: &Path, package_type: &str) {
+    assert_ne!(package_path.as_os_str(), "");
+    assert_ne!(package_path.as_os_str(), "/");
 
-    let package_path = Path::new(package_dir);
     let exists = package_path.exists();
     if !exists {
         return;
     }
 
-    let cargo_fn = String::from(format!("{}/Cargo.toml", package_dir));
-    let cargo_path = Path::new(&cargo_fn);
+    let cargo_path = package_path.join("Cargo.toml");
     let exists = cargo_path.exists();
     if exists {
-        remove_file(cargo_fn).unwrap();
+        remove_file(cargo_path).unwrap();
     }
 
-    let src_fn =
+    let src_path =
         match package_type {
             "bin" => {
-                String::from(format!("{}/src/main.rs", package_dir))
+                package_path.join("src").join("main.rs")
             },
             "lib" => {
-                String::from(format!("{}/src/lib.rs", package_dir))
+                package_path.join("src").join("lib.rs")
             },
             _ => {
                 return;
             },
         };
 
-    let src_path = Path::new(&src_fn);
     let exists = src_path.exists();
     if exists {
-        remove_file(src_fn).unwrap();
+        remove_file(src_path).unwrap();
     }
 
-    let src_fn = String::from(format!("{}/src", package_dir));
-    let src_path = Path::new(&src_fn);
+    let src_path = package_path.join("src");
     let exists = src_path.exists();
     if exists {
-        remove_dir(src_fn).unwrap();
+        remove_dir(src_path).unwrap();
     }
 
-    let package_path = Path::new(package_dir);
     let exists = package_path.exists();
     if exists {
-        remove_dir(package_dir).unwrap();
+        remove_dir(package_path).unwrap();
     }
 }
 
@@ -63,20 +58,21 @@ fn clean_package_dir(package_dir: &String, package_type: &str) {
 fn test_create_bin_2015() {
     let package_name = "mynewcrate-bin-2015";
     let dir = "../fixtures/normal";
-    let package_dir = format!("{}/{}", dir, package_name);
+    let package_path = Path::new(dir).join(package_name);
+    let manifest_path = package_path.join("Cargo.toml");
 
-    clean_package_dir(&package_dir, "bin");
+    clean_package_dir(&package_path, "bin");
 
     let _err = utils::run_err(dir,
                               &["ws", "create", package_name,
                                 "--edition", "2015", "--bin",
                                 "--name", package_name]);
 
-    let manifest = read_to_string(format!("{}/Cargo.toml", package_dir)).unwrap();
+    let manifest = read_to_string(manifest_path).unwrap();
 
     assert_snapshot!(&manifest);
 
-    clean_package_dir(&package_dir, "bin");
+    clean_package_dir(&package_path, "bin");
 }
 
 /// Test creating a 2015 lib package
@@ -84,20 +80,21 @@ fn test_create_bin_2015() {
 fn test_create_lib_2015() {
     let package_name = "mynewcrate-lib-2015";
     let dir = "../fixtures/normal";
-    let package_dir = format!("{}/{}", dir, package_name);
+    let package_path = Path::new(dir).join(package_name);
+    let manifest_path = package_path.join("Cargo.toml");
 
-    clean_package_dir(&package_dir, "lib");
+    clean_package_dir(&package_path, "lib");
 
     let _err = utils::run_err(dir,
                               &["ws", "create", package_name,
                                 "--edition", "2015", "--lib",
                                 "--name", package_name]);
 
-    let manifest = read_to_string(format!("{}/Cargo.toml", package_dir)).unwrap();
+    let manifest = read_to_string(manifest_path).unwrap();
 
     assert_snapshot!(&manifest);
 
-    clean_package_dir(&package_dir, "lib");
+    clean_package_dir(&package_path, "lib");
 }
 
 /// Test creating a 2018 bin package
@@ -105,20 +102,21 @@ fn test_create_lib_2015() {
 fn test_create_bin_2018() {
     let package_name = "mynewcrate-bin-2018";
     let dir = "../fixtures/normal";
-    let package_dir = format!("{}/{}", dir, package_name);
+    let package_path = Path::new(dir).join(package_name);
+    let manifest_path = package_path.join("Cargo.toml");
 
-    clean_package_dir(&package_dir, "bin");
+    clean_package_dir(&package_path, "bin");
 
     let _err = utils::run_err(dir,
                               &["ws", "create", package_name,
                                 "--edition", "2018", "--bin",
                                 "--name", package_name]);
 
-    let manifest = read_to_string(format!("{}/Cargo.toml", package_dir)).unwrap();
+    let manifest = read_to_string(manifest_path).unwrap();
 
     assert_snapshot!(&manifest);
 
-    clean_package_dir(&package_dir, "bin");
+    clean_package_dir(&package_path, "bin");
 }
 
 /// Test creating a 2018 lib package
@@ -126,20 +124,21 @@ fn test_create_bin_2018() {
 fn test_create_lib_2018() {
     let package_name = "mynewcrate-lib-2018";
     let dir = "../fixtures/normal";
-    let package_dir = format!("{}/{}", dir, package_name);
+    let package_path = Path::new(dir).join(package_name);
+    let manifest_path = package_path.join("Cargo.toml");
 
-    clean_package_dir(&package_dir, "lib");
+    clean_package_dir(&package_path, "lib");
 
     let _err = utils::run_err(dir,
                               &["ws", "create", package_name,
                                 "--edition", "2018", "--lib",
                                 "--name", package_name]);
 
-    let manifest = read_to_string(format!("{}/Cargo.toml", package_dir)).unwrap();
+    let manifest = read_to_string(manifest_path).unwrap();
 
     assert_snapshot!(&manifest);
 
-    clean_package_dir(&package_dir, "lib");
+    clean_package_dir(&package_path, "lib");
 }
 
 /// Test that you can't create a library and binary package at the same time
@@ -147,10 +146,10 @@ fn test_create_lib_2018() {
 fn test_create_lib_and_bin_fails() {
     let package_name = "mynewcrate-lib-and-bin-2018";
     let dir = "../fixtures/normal";
-    let package_dir = format!("{}/{}", dir, package_name);
+    let package_path = Path::new(dir).join(package_name);
 
-    clean_package_dir(&package_dir, "lib");
-    clean_package_dir(&package_dir, "bin");
+    clean_package_dir(&package_path, "lib");
+    clean_package_dir(&package_path, "bin");
 
     let err = utils::run_err(dir,
                              &["ws", "create", package_name,
@@ -162,10 +161,9 @@ fn test_create_lib_and_bin_fails() {
     assert!(err.contains("cannot be used with"));
     assert!(err.contains("--lib"));
 
-    let package_path = Path::new(&package_dir);
     let exists = package_path.exists();
     assert!(!exists);
 
-    clean_package_dir(&package_dir, "lib");
-    clean_package_dir(&package_dir, "bin");
+    clean_package_dir(&package_path, "lib");
+    clean_package_dir(&package_path, "bin");
 }

--- a/cargo-workspaces/tests/create.rs
+++ b/cargo-workspaces/tests/create.rs
@@ -1,7 +1,9 @@
 mod utils;
 use insta::assert_snapshot;
-use std::fs::{read_to_string, remove_dir, remove_file};
-use std::path::Path;
+use std::{
+    fs::{read_to_string, remove_dir, remove_file},
+    path::Path,
+};
 
 /// Clean up a cargo or cargo-workspace created package directory
 /// This doesn't use remove_dir_all, so it's safer, but more liable to break
@@ -23,18 +25,13 @@ fn clean_package_dir(package_path: &Path, package_type: &str) {
         remove_file(cargo_path).unwrap();
     }
 
-    let src_path =
-        match package_type {
-            "bin" => {
-                package_path.join("src").join("main.rs")
-            },
-            "lib" => {
-                package_path.join("src").join("lib.rs")
-            },
-            _ => {
-                return;
-            },
-        };
+    let src_path = match package_type {
+        "bin" => package_path.join("src").join("main.rs"),
+        "lib" => package_path.join("src").join("lib.rs"),
+        _ => {
+            return;
+        }
+    };
 
     let exists = src_path.exists();
     if exists {
@@ -63,10 +60,19 @@ fn test_create_bin_2015() {
 
     clean_package_dir(&package_path, "bin");
 
-    let _err = utils::run_err(dir,
-                              &["ws", "create", package_name,
-                                "--edition", "2015", "--bin",
-                                "--name", package_name]);
+    let _err = utils::run_err(
+        dir,
+        &[
+            "ws",
+            "create",
+            package_name,
+            "--edition",
+            "2015",
+            "--bin",
+            "--name",
+            package_name,
+        ],
+    );
 
     let manifest = read_to_string(manifest_path).unwrap();
 
@@ -85,10 +91,19 @@ fn test_create_lib_2015() {
 
     clean_package_dir(&package_path, "lib");
 
-    let _err = utils::run_err(dir,
-                              &["ws", "create", package_name,
-                                "--edition", "2015", "--lib",
-                                "--name", package_name]);
+    let _err = utils::run_err(
+        dir,
+        &[
+            "ws",
+            "create",
+            package_name,
+            "--edition",
+            "2015",
+            "--lib",
+            "--name",
+            package_name,
+        ],
+    );
 
     let manifest = read_to_string(manifest_path).unwrap();
 
@@ -107,10 +122,19 @@ fn test_create_bin_2018() {
 
     clean_package_dir(&package_path, "bin");
 
-    let _err = utils::run_err(dir,
-                              &["ws", "create", package_name,
-                                "--edition", "2018", "--bin",
-                                "--name", package_name]);
+    let _err = utils::run_err(
+        dir,
+        &[
+            "ws",
+            "create",
+            package_name,
+            "--edition",
+            "2018",
+            "--bin",
+            "--name",
+            package_name,
+        ],
+    );
 
     let manifest = read_to_string(manifest_path).unwrap();
 
@@ -129,10 +153,19 @@ fn test_create_lib_2018() {
 
     clean_package_dir(&package_path, "lib");
 
-    let _err = utils::run_err(dir,
-                              &["ws", "create", package_name,
-                                "--edition", "2018", "--lib",
-                                "--name", package_name]);
+    let _err = utils::run_err(
+        dir,
+        &[
+            "ws",
+            "create",
+            package_name,
+            "--edition",
+            "2018",
+            "--lib",
+            "--name",
+            package_name,
+        ],
+    );
 
     let manifest = read_to_string(manifest_path).unwrap();
 
@@ -151,10 +184,20 @@ fn test_create_lib_and_bin_fails() {
     clean_package_dir(&package_path, "lib");
     clean_package_dir(&package_path, "bin");
 
-    let err = utils::run_err(dir,
-                             &["ws", "create", package_name,
-                               "--edition", "2018", "--lib", "--bin",
-                               "--name", package_name]);
+    let err = utils::run_err(
+        dir,
+        &[
+            "ws",
+            "create",
+            package_name,
+            "--edition",
+            "2018",
+            "--lib",
+            "--bin",
+            "--name",
+            package_name,
+        ],
+    );
 
     assert!(err.contains("error"));
     assert!(err.contains("--bin"));

--- a/cargo-workspaces/tests/snapshots/create__create_bin_2015.snap
+++ b/cargo-workspaces/tests/snapshots/create__create_bin_2015.snap
@@ -1,0 +1,13 @@
+---
+source: tests/create.rs
+expression: "&manifest"
+
+---
+[package]
+name = "mynewcrate-bin-2015"
+version = "0.0.0"
+edition = "2015"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/cargo-workspaces/tests/snapshots/create__create_bin_2018.snap
+++ b/cargo-workspaces/tests/snapshots/create__create_bin_2018.snap
@@ -1,0 +1,13 @@
+---
+source: tests/create.rs
+expression: "&manifest"
+
+---
+[package]
+name = "mynewcrate-bin-2018"
+version = "0.0.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/cargo-workspaces/tests/snapshots/create__create_lib_2015.snap
+++ b/cargo-workspaces/tests/snapshots/create__create_lib_2015.snap
@@ -1,0 +1,13 @@
+---
+source: tests/create.rs
+expression: "&manifest"
+
+---
+[package]
+name = "mynewcrate-lib-2015"
+version = "0.0.0"
+edition = "2015"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/cargo-workspaces/tests/snapshots/create__create_lib_2018.snap
+++ b/cargo-workspaces/tests/snapshots/create__create_lib_2018.snap
@@ -1,0 +1,13 @@
+---
+source: tests/create.rs
+expression: "&manifest"
+
+---
+[package]
+name = "mynewcrate-lib-2018"
+version = "0.0.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]


### PR DESCRIPTION
Add additional arguments to the create subcommand that match the cargo options.  This adds support for running the create subcommand without prompts.  Add tests around the create subcommand.

This was added in preparation for new code to support --dry-run.  It simplifies testing around the create command and other commands that are destructive.

There are some design decisions here that may not match the rest of the application.

1. It doesn't use a mock library to do filesystem operations and cleans up the directory manually.
2. It's tied to the existing crate/package format, so may break on future changes to the cargo template projects.

Let me know what you think and if you have any changes.  Thanks for the work on the project, it's a great example of the power of clap.