### PR TITLE
impl workaround for silencing build target redundancy warning

### DIFF
--- a/cargo-workspaces/Cargo.toml
+++ b/cargo-workspaces/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 
 [[bin]]
 name = "cargo-ws"
-path = "src/main.rs"
+path = "src/../src/main.rs"
 test = false
 bench = false
 


### PR DESCRIPTION
Apply workaround for hiding this warning

```console
$ cargo build
warning: /git/pksunkara/cargo-workspaces/cargo-workspaces/Cargo.toml: file found to be present in multiple build targets: /git/pksunkara/cargo-workspaces/cargo-workspaces/src/main.rs
```

Differing paths between targets tricks cargo into thinking they're different files, whereas when normalized, they're one and the same.