### PR TITLE
Clean up the git files during package tests

### DIFF
--- a/cargo-workspaces/tests/create.rs
+++ b/cargo-workspaces/tests/create.rs
@@ -1,7 +1,7 @@
 mod utils;
 use insta::assert_snapshot;
 use std::{
-    fs::{read_to_string, remove_dir, remove_file},
+    fs::{read_to_string, remove_dir, remove_dir_all, remove_file},
     path::Path,
 };
 
@@ -42,6 +42,14 @@ fn clean_package_dir(package_path: &Path, package_type: &str) {
     let exists = src_path.exists();
     if exists {
         remove_dir(src_path).unwrap();
+    }
+
+    let git_path = package_path.join(".git");
+    let gitignore_path = package_path.join(".gitignore");
+    let exists = git_path.exists();
+    if exists {
+        remove_dir_all(git_path).unwrap();
+        remove_file(gitignore_path).unwrap();
     }
 
     let exists = package_path.exists();


### PR DESCRIPTION
I came across the following error while running tests in a clean chroot:

```
running 5 tests
test test_create_bin_2015 ... thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 39, kind: DirectoryNotEmpty, message: "Directory not empty" }', tests/create.rs:51:30
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
FAILED
test test_create_bin_2018 ... thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 39, kind: DirectoryNotEmpty, message: "Directory not empty" }', tests/create.rs:51:30
FAILED
test test_create_lib_2015 ... thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 39, kind: DirectoryNotEmpty, message: "Directory not empty" }', tests/create.rs:51:30
FAILED
test test_create_lib_2018 ... thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 39, kind: DirectoryNotEmpty, message: "Directory not empty" }', tests/create.rs:51:30
FAILED
test test_create_lib_and_bin_fails ... ok

failures:

failures:
    test_create_bin_2015
    test_create_bin_2018
    test_create_lib_2015
    test_create_lib_2018

test result: FAILED. 1 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.21s

error: test failed, to rerun pass '--test create'
```

It turns out `.git/` and `.gitignore` is created along with the package so that's why those tests are failing.

This PR fixes this issue by cleaning up the git related files/directories from the test directory if they exist.

