### PR TITLE
add --exclude-libs to list

### DIFF
--- a/cargo-workspaces/src/list.rs
+++ b/cargo-workspaces/src/list.rs
@@ -12,7 +12,7 @@ pub struct List {
 
 impl List {
     pub fn run(self, metadata: Metadata) -> Result {
-        let pkgs = get_pkgs(&metadata, self.list.all)?;
+        let pkgs = get_pkgs(&metadata, self.list.all, self.list.exclude_lib)?;
         pkgs.list(self.list)
     }
 }

--- a/cargo-workspaces/src/rename.rs
+++ b/cargo-workspaces/src/rename.rs
@@ -26,7 +26,7 @@ pub struct Rename {
 
 impl Rename {
     pub fn run(self, metadata: Metadata) -> Result<(), Error> {
-        let pkgs = get_pkgs(&metadata, self.all || self.from.is_some())?;
+        let pkgs = get_pkgs(&metadata, self.all || self.from.is_some(), false)?;
 
         let ignore = self
             .ignore

--- a/cargo-workspaces/src/utils/changable.rs
+++ b/cargo-workspaces/src/utils/changable.rs
@@ -77,7 +77,7 @@ impl ChangeOpt {
         since: &Option<String>,
         private: bool,
     ) -> Result<(Vec<Pkg>, Vec<Pkg>), Error> {
-        let pkgs = get_pkgs(metadata, private)?;
+        let pkgs = get_pkgs(metadata, private, false)?;
 
         let pkgs = if let Some(since) = since {
             info!("looking for changes since", since);

--- a/cargo-workspaces/src/utils/listable.rs
+++ b/cargo-workspaces/src/utils/listable.rs
@@ -26,4 +26,8 @@ pub struct ListOpt {
     /// Show information as a JSON array
     #[clap(long, conflicts_with = "long")]
     pub json: bool,
+
+    /// Exclude any crates with lib target
+    #[clap(short, long, conflicts_with = "all")]
+    pub exclude_lib: bool,
 }

--- a/cargo-workspaces/src/utils/listable.rs
+++ b/cargo-workspaces/src/utils/listable.rs
@@ -27,7 +27,7 @@ pub struct ListOpt {
     #[clap(long, conflicts_with = "long")]
     pub json: bool,
 
-    /// Exclude any crates with lib target
+    /// Exclude any packages if they contain a single lib target
     #[clap(short, long, conflicts_with = "all")]
     pub exclude_lib: bool,
 }

--- a/cargo-workspaces/src/utils/pkg.rs
+++ b/cargo-workspaces/src/utils/pkg.rs
@@ -86,15 +86,19 @@ impl Listable for Vec<Pkg> {
     }
 }
 
-pub fn get_pkgs(metadata: &Metadata, all: bool) -> Result<Vec<Pkg>> {
+pub fn get_pkgs(metadata: &Metadata, all: bool, exclude_lib: bool) -> Result<Vec<Pkg>> {
     let mut pkgs = vec![];
 
     for id in &metadata.workspace_members {
         if let Some(pkg) = metadata.packages.iter().find(|x| x.id == *id) {
             let private =
                 pkg.publish.is_some() && pkg.publish.as_ref().expect(INTERNAL_ERR).is_empty();
+            let has_only_lib_target = pkg
+                .targets
+                .iter()
+                .all(|t| t.kind.iter().all(|k| k == "lib"));
 
-            if !all && private {
+            if (!all && private) || (exclude_lib && has_only_lib_target) {
                 continue;
             }
 


### PR DESCRIPTION
i have a project that contains a lot of bins and a few libs, i have a build script that needs to pick out the bin packages only so i know which packages to publish and which to not publish

here i add --exclude-libs option to the list command so i can run `cargo workspaces list --exclude-lib` to filter out libs

i appreciate this may not be the direction you'd like to take for list, so happy to discuss alternatives!