### PR TITLE
docs: clarify version-placeholde for commit msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ GIT OPTIONS:
         --amend                             Amend the existing commit, instead of generating a new one
         --git-remote <remote>               Push git changes to the specified remote [default: origin]
         --individual-tag-prefix <prefix>    Customize prefix for individual tags (should contain `%n`) [default: %n@]
-    -m, --message <MESSAGE>                 Use a custom commit message when creating the version commit
+    -m, --message <MESSAGE>                 Use a custom commit message when creating the version commit (use: `%v` for the new version)
         --no-git-commit                     Do not commit version changes
         --no-git-push                       Do not push generated commit and tags to git remote
         --no-git-tag                        Do not tag generated commit
@@ -231,7 +231,7 @@ GIT OPTIONS:
         --amend                             Amend the existing commit, instead of generating a new one
         --git-remote <remote>               Push git changes to the specified remote [default: origin]
         --individual-tag-prefix <prefix>    Customize prefix for individual tags (should contain `%n`) [default: %n@]
-    -m, --message <MESSAGE>                 Use a custom commit message when creating the version commit
+    -m, --message <MESSAGE>                 Use a custom commit message when creating the version commit (use: `%v` for the new version)
         --no-git-commit                     Do not commit version changes
         --no-git-push                       Do not push generated commit and tags to git remote
         --no-git-tag                        Do not tag generated commit

--- a/cargo-workspaces/src/utils/git.rs
+++ b/cargo-workspaces/src/utils/git.rs
@@ -53,7 +53,7 @@ pub struct GitOpt {
     #[clap(long)]
     pub amend: bool,
 
-    /// Use a custom commit message when creating the version commit
+    /// Use a custom commit message when creating the version commit (use: `%v` as placeholder for the new version)
     #[clap(
         short,
         long,


### PR DESCRIPTION
Since i had to look into the code in order find the '%v' version placeholder for the commit message. I though it might help to clarify it in the --help description of  `-m, --message` like it is done for `--individual-tag-prefix`

Before:
```console
foo@bar:~$ cargo ws version --help
[...]
 -m, --message <MESSAGE>                 Use a custom commit message when creating the version commit
[...]
```

After:
```console
foo@bar:~$ cargo ws version --help
[...]
-m, --message <MESSAGE>                 Use a custom commit message when creating the version commit (use: `%v` for the new version)
[...]
```