### PR TITLE
add --ignore option to exec command

### DIFF
--- a/cargo-workspaces/tests/exec.rs
+++ b/cargo-workspaces/tests/exec.rs
@@ -16,3 +16,15 @@ fn test_normal() {
     assert_snapshot!(err);
     assert_snapshot!(out);
 }
+
+// TODO: Get exec test working on windows
+#[cfg(not(windows))]
+#[test]
+fn test_normal_ignore() {
+    let (out, err) = utils::run(
+        "../fixtures/normal",
+        &["ws", "exec", "--ignore={dep2,top}", PRINT, "Cargo.toml"],
+    );
+    assert_snapshot!(err);
+    assert_snapshot!(out);
+}

--- a/cargo-workspaces/tests/snapshots/exec__normal_ignore-2.snap
+++ b/cargo-workspaces/tests/snapshots/exec__normal_ignore-2.snap
@@ -1,0 +1,14 @@
+---
+source: tests/exec.rs
+assertion_line: 29
+expression: out
+
+---
+[package]
+name = "dep1"
+version = "0.1.0"
+authors = ["Pavan Kumar Sunkara <pavan.sss1991@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+

--- a/cargo-workspaces/tests/snapshots/exec__normal_ignore.snap
+++ b/cargo-workspaces/tests/snapshots/exec__normal_ignore.snap
@@ -1,0 +1,8 @@
+---
+source: tests/exec.rs
+assertion_line: 28
+expression: err
+
+---
+info success ok
+


### PR DESCRIPTION
This uses similar logic to the `--ignore` in rename. It allows for a comma delimited list of ignores. We should probably update the other ignore to match this logic, maybe?

fixes: #97 