### PR TITLE
feat: Check appropriate registry for index when providing --registry option

### DIFF
--- a/cargo-workspaces/src/publish.rs
+++ b/cargo-workspaces/src/publish.rs
@@ -88,16 +88,14 @@ impl Publish {
 
             let name_ver = format!("{} v{}", name, version);
 
-            let mut index = if let Some(registry) = self.registry.as_deref() {
+            let mut index = if let Some(registry) = self
+                .registry
+                .as_ref()
+                .or_else(|| pkg.publish.as_deref().and_then(|x| x.get(0)))
+            {
                 let registry_url = cargo_config_get(
                     &metadata.workspace_root,
                     &format!("registries.{}.index", registry),
-                )?;
-                Index::from_url(&format!("registry+{}", registry_url))?
-            } else if let Some(publish) = pkg.publish.as_deref().and_then(|x| x.get(0)) {
-                let registry_url = cargo_config_get(
-                    &metadata.workspace_root,
-                    &format!("registries.{}.index", publish),
                 )?;
                 Index::from_url(&format!("registry+{}", registry_url))?
             } else {

--- a/cargo-workspaces/src/publish.rs
+++ b/cargo-workspaces/src/publish.rs
@@ -88,16 +88,21 @@ impl Publish {
 
             let name_ver = format!("{} v{}", name, version);
 
-            let mut index =
-                if let Some(publish) = pkg.publish.as_deref().and_then(|x| x.get(0)).as_deref() {
-                    let registry_url = cargo_config_get(
-                        &metadata.workspace_root,
-                        &format!("registries.{}.index", publish),
-                    )?;
-                    Index::from_url(&format!("registry+{}", registry_url))?
-                } else {
-                    Index::new_cargo_default()?
-                };
+            let mut index = if let Some(registry) = self.registry.as_deref() {
+                let registry_url = cargo_config_get(
+                    &metadata.workspace_root,
+                    &format!("registries.{}.index", registry),
+                )?;
+                Index::from_url(&format!("registry+{}", registry_url))?
+            } else if let Some(publish) = pkg.publish.as_deref().and_then(|x| x.get(0)) {
+                let registry_url = cargo_config_get(
+                    &metadata.workspace_root,
+                    &format!("registries.{}.index", publish),
+                )?;
+                Index::from_url(&format!("registry+{}", registry_url))?
+            } else {
+                Index::new_cargo_default()?
+            };
 
             if is_published(&mut index, &name, version)? {
                 info!("already published", name_ver);


### PR DESCRIPTION
Currently, the index is taken either from the first registry in the `publish` list of the `Cargo.toml` or from the crates.io index. However, if the `--registry` option is provided, it makes more sense to use the index from the provided registry.

This PR takes the index from the registry provided if the `--registry` option is set.