### PR TITLE
publish: add possibility to use --dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ GIT OPTIONS:
 
 PUBLISH OPTIONS:
         --allow-dirty            Allow dirty working directories to be published
+        --dry-run                Check publication feasibility, but do not actually publish
         --from-git               Publish crates from the current commit without versioning
         --no-remove-dev-deps     Don't remove dev-dependencies while publishing
         --no-verify              Skip crate verification (not recommended)

--- a/cargo-workspaces/src/publish.rs
+++ b/cargo-workspaces/src/publish.rs
@@ -31,6 +31,10 @@ pub struct Publish {
     #[clap(long)]
     allow_dirty: bool,
 
+    /// Check publication feasibility, but do not actually publish
+    #[clap(long)]
+    dry_run: bool,
+
     /// The token to use for publishing
     #[clap(long, forbid_empty_values(true))]
     token: Option<String>,
@@ -117,6 +121,10 @@ impl Publish {
 
             if self.allow_dirty {
                 args.push("--allow-dirty");
+            }
+
+            if self.dry_run {
+                args.push("--dry-run");
             }
 
             if let Some(ref registry) = self.registry {


### PR DESCRIPTION
The --dry-run flag is very useful to build and prepare for releasing, check for server availability, but do not actually push to the server.