### PR TITLE
Feat/update workspace members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## 0.3.0
+
 ### BREAKING
 * Update MSRV to 1.70.0
 
 ### Enhancements
 * Renamed `--from-git` flag to `--publish-as-is`
+* Add new workspace member entry automatically when creating it
 
 ### Bug Fixes
 * Respect protocols in registry URLs

--- a/cargo-workspaces/src/create.rs
+++ b/cargo-workspaces/src/create.rs
@@ -1,12 +1,20 @@
 use crate::utils::{cargo, change_versions, info, Error, Result, INTERNAL_ERR};
 
+use camino::Utf8PathBuf;
 use cargo_metadata::Metadata;
 use clap::{ArgEnum, Parser};
 use dialoguer::{theme::ColorfulTheme, Input, Select};
+use dunce::canonicalize;
+use glob::Pattern;
 use oclif::term::TERM_ERR;
 use semver::Version;
+use toml_edit::{Array, Decor, Document, Formatted, Item, Table, Value};
 
-use std::{collections::BTreeMap as Map, fs};
+use std::{
+    collections::BTreeMap as Map,
+    env::current_dir,
+    fs::{create_dir_all, read_to_string, remove_dir_all, remove_file, write},
+};
 
 #[derive(Debug, Clone, ArgEnum)]
 enum Edition {
@@ -43,8 +51,67 @@ pub struct Create {
 
 impl Create {
     pub fn run(&self, metadata: Metadata) -> Result {
+        if canonicalize(&metadata.workspace_root)? != canonicalize(current_dir()?)? {
+            return Err(Error::MustBeRunFromWorkspaceRoot);
+        }
+
+        let workspace_root = metadata.workspace_root.join("Cargo.toml");
+        let backup = read_to_string(&workspace_root)?;
+
+        self.try_run(metadata).or_else(|e| {
+            // cleanup itself may fail and we want to notify the user in that case
+            // otherwise just propagate the error that caused the cleanup
+            cleanup(&workspace_root, backup, &self.path).and(Err(e))
+        })?;
+
+        info!("success", "ok");
+
+        Ok(())
+    }
+
+    fn try_run(&self, metadata: Metadata) -> Result {
+        create_dir_all(&self.path)?;
+
+        if !canonicalize(&metadata.workspace_root.join(&self.path))?
+            .starts_with(canonicalize(&metadata.workspace_root)?)
+        {
+            return Err(Error::InvalidMemberPath);
+        }
+
+        self.add_workspace_toml_entry(&metadata)?;
+        self.create_new_workspace_member(&metadata)?;
+
+        Ok(())
+    }
+
+    // adds info about new member to workspace's Cargo.toml file
+    //
+    // # Fails if
+    //
+    // - toml files are generally corrupted
+    // - exclude list contains new member's name
+    // - members list contains new member's name
+    fn add_workspace_toml_entry(&self, metadata: &Metadata) -> Result {
+        let workspace_root = metadata.workspace_root.join("Cargo.toml");
+        let mut workspace_manifest = read_to_string(&workspace_root)?.parse::<Document>()?;
+
+        add_workspace_member(metadata, &mut workspace_manifest, &self.path)?;
+
+        write(workspace_root, workspace_manifest.to_string())?;
+
+        Ok(())
+    }
+
+    // creates new member crate
+    //
+    // # Fails if
+    //
+    // - conflicting options were chosen
+    // - `cargo new` fails
+    // - another package with the same name was already created somewhere
+    fn create_new_workspace_member(&self, metadata: &Metadata) -> Result {
         let theme = ColorfulTheme::default();
-        let path = &metadata.workspace_root.join(&self.path);
+        let path = metadata.workspace_root.join(&self.path);
 
         let name = match &self.name {
             Some(n) => n.clone(),
@@ -53,15 +120,13 @@ impl Create {
                 .interact_on(&TERM_ERR)?,
         };
 
-        let types = vec!["library", "binary"];
-
         let template = if self.lib {
             0
         } else if self.bin {
             1
         } else {
             Select::with_theme(&theme)
-                .items(&types)
+                .items(&["library", "binary"])
                 .default(1)
                 .with_prompt("Type of the crate")
                 .interact_on(&TERM_ERR)?
@@ -85,13 +150,7 @@ impl Create {
                 .interact_on(&TERM_ERR)?,
         };
 
-        let mut args = vec![
-            "new",
-            "--name",
-            name.as_str(),
-            "--edition",
-            editions[edition],
-        ];
+        let mut args = vec!["new", "--name", &name, "--edition", editions[edition]];
 
         if template == 0 {
             args.push("--lib");
@@ -101,25 +160,129 @@ impl Create {
 
         args.push(path.as_str());
 
-        let created = cargo(&metadata.workspace_root, &args, &[])?;
+        let (stdout, stderr) = cargo(&metadata.workspace_root, &args, &[])?;
 
-        if !created.1.contains("Created") {
+        if [&stdout, &stderr]
+            .iter()
+            .any(|out| out.contains("two packages"))
+        {
+            return Err(Error::DuplicatePackageName);
+        }
+
+        if !stderr.contains("Created") {
             return Err(Error::Create);
         }
 
         let manifest = path.join("Cargo.toml");
         let mut versions = Map::new();
 
-        versions.insert(name.clone(), Version::parse("0.0.0").expect(INTERNAL_ERR));
+        versions.insert(
+            name.to_owned(),
+            Version::parse("0.0.0").expect(INTERNAL_ERR),
+        );
 
-        fs::write(
+        write(
             &manifest,
-            change_versions(fs::read_to_string(&manifest)?, &name, &versions, false)?,
+            change_versions(read_to_string(&manifest)?, &name, &versions, false)?,
         )?;
 
-        // TODO: If none of the globs in workspace `members` match, add a new entry
-
-        info!("success", "ok");
         Ok(())
     }
+}
+
+fn cleanup(workspace_root: &Utf8PathBuf, backup: String, path: &str) -> Result {
+    // reset manifest doc
+    remove_file(workspace_root)?;
+    write(workspace_root, backup)?;
+
+    // remove created crate, might not be there so ignore errors
+    _ = remove_dir_all(path);
+
+    // cleanup successful
+    Ok(())
+}
+
+fn add_workspace_member(
+    metadata: &Metadata,
+    manifest: &mut Document,
+    new_member_path: &str,
+) -> Result {
+    let path = metadata.workspace_root.join(new_member_path).to_string();
+
+    let workspace_table = manifest
+        .entry("workspace")
+        .or_insert(Item::Table(Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| {
+            Error::WorkspaceBadFormat("workspace manifest item must be a table".into())
+        })?;
+
+    if let Some(exclude_item) = workspace_table.get("exclude") {
+        if let Some(pattern) =
+            exists_in_glob_list(metadata, exclude_item, &path, "workspace.exclude")?
+        {
+            return Err(Error::InWorkspaceExclude(pattern.into()));
+        }
+    }
+
+    let members_item = workspace_table
+        .entry("members")
+        .or_insert(Item::Value(Value::Array(Array::new())));
+
+    // If the member is already in the members list, we don't need to do anything
+    if exists_in_glob_list(metadata, members_item, &path, "workspace.members")?.is_some() {
+        return Ok(());
+    }
+
+    let members_array = members_item.as_array_mut().expect(INTERNAL_ERR);
+
+    let existing_prefix = members_array
+        .iter()
+        .next()
+        .and_then(|item| item.decor().prefix().cloned());
+
+    let existing_suffix = members_array
+        .iter()
+        .next()
+        .and_then(|item| item.decor().suffix().cloned());
+
+    let decor = Decor::new(
+        existing_prefix.unwrap_or_else(|| "\n  ".into()),
+        existing_suffix.unwrap_or_else(|| ",\n".into()),
+    );
+
+    let mut new_elem = Value::String(Formatted::new(new_member_path.to_owned()));
+    *new_elem.decor_mut() = decor;
+
+    members_array.push_formatted(new_elem);
+
+    Ok(())
+}
+
+fn exists_in_glob_list<'a>(
+    metadata: &'a Metadata,
+    array_item: &'a Item,
+    path: &'a str,
+    error_name: &'a str,
+) -> Result<Option<&'a str>> {
+    let paths = array_item
+        .as_array()
+        .ok_or_else(|| {
+            Error::WorkspaceBadFormat(format!("{error_name} manifest item must be an array"))
+        })?
+        .iter()
+        .map(|elem| {
+            elem.as_str().ok_or_else(|| {
+                Error::WorkspaceBadFormat(format!("{error_name} manifest items must be strings"))
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    for pattern in paths {
+        if Pattern::new(&format!("{}/{pattern}", metadata.workspace_root))?.matches(path) {
+            return Ok(Some(pattern));
+        }
+    }
+
+    Ok(None)
 }

--- a/cargo-workspaces/src/utils/error.rs
+++ b/cargo-workspaces/src/utils/error.rs
@@ -73,6 +73,8 @@ pub enum Error {
     ManifestHasNoParent(String),
     #[error("unable to read metadata specified in Cargo.toml: {0}")]
     BadMetadata(serde_json::Error),
+    #[error("command needs to be run from the workspace root")]
+    MustBeRunFromWorkspaceRoot,
 
     #[error("unable to verify package {0}")]
     Verify(String),
@@ -86,6 +88,12 @@ pub enum Error {
 
     #[error("unable to create crate")]
     Create,
+    #[error("path for crate is in workspace.exclude list ({0})")]
+    InWorkspaceExclude(String),
+    #[error("member path is not inside workspace root")]
+    InvalidMemberPath,
+    #[error("the workspace already contains a package with this name")]
+    DuplicatePackageName,
 
     #[error("given path {0} is not a folder")]
     WorkspaceRootNotDir(String),
@@ -130,10 +138,15 @@ pub enum Error {
     #[error("crates index error: {0}")]
     CratesReqwest(#[from] tame_index::external::reqwest::Error),
 
+    #[error("the workspace manifest has bad format: {0}")]
+    WorkspaceBadFormat(String),
+
     #[error("{0}")]
     Semver(#[from] semver::ReqParseError),
     #[error("{0}")]
-    Glob(#[from] glob::PatternError),
+    Glob(#[from] glob::GlobError),
+    #[error("{0}")]
+    GlobPattern(#[from] glob::PatternError),
     #[error("{0}")]
     Globset(#[from] globset::Error),
     #[error("{0}")]


### PR DESCRIPTION
Picking up #105 

I'll describe it better soon

---

## Regarding the formatting

- It keeps the same whitespace style
  ```
  [workspace]
  members = [
        "a",
  ]
  ```
  to
  ```
  [workspace]
  members = [
        "a",
        "b",
  ]
  ```
- it defaults to newline style
  ```
  [workspace]
  ```
  or 
  ```
  [workspace]
  members = []
  ```
  to 
  ```
  [workspace]
  members = [
    "a",
  ]
  ```
  and
- it actually also keeps the inline formatting if it's there
  ```
  [workspace]
  members = [ "a", "b", "c", ]
  ```
  to
  ```
  [workspace]
  members = [ "a", "b", "c", "d", ]
  ```

---

Bugs:

- if `./b` exists and we create `cargo ws create abc/b` then it fails and deletes `./b` because of the cleanup