### PR TITLE
feat: try to infer package name from path

### DIFF
--- a/cargo-workspaces/src/create.rs
+++ b/cargo-workspaces/src/create.rs
@@ -120,14 +120,10 @@ impl Create {
         let theme = ColorfulTheme::default();
         let path = metadata.workspace_root.join(&self.path);
 
-        let name = match self
-            .name
-            .as_deref()
-            .or_else(|| path.file_name())
-            .map(|s| s.to_owned())
-        {
-            Some(n) => n,
+        let name = match self.name.as_ref() {
+            Some(n) => n.to_owned(),
             None => Input::with_theme(&theme)
+                .default(path.file_name().map(|s| s.to_owned()).unwrap_or_default())
                 .with_prompt("Name of the crate")
                 .interact_on(&TERM_ERR)?,
         };

--- a/cargo-workspaces/src/create.rs
+++ b/cargo-workspaces/src/create.rs
@@ -120,8 +120,13 @@ impl Create {
         let theme = ColorfulTheme::default();
         let path = metadata.workspace_root.join(&self.path);
 
-        let name = match &self.name {
-            Some(n) => n.clone(),
+        let name = match self
+            .name
+            .as_deref()
+            .or_else(|| path.file_name())
+            .map(|s| s.to_owned())
+        {
+            Some(n) => n,
             None => Input::with_theme(&theme)
                 .with_prompt("Name of the crate")
                 .interact_on(&TERM_ERR)?,


### PR DESCRIPTION
Tries to solve this comment

https://github.com/pksunkara/cargo-workspaces/issues/46#issuecomment-1229234635

The basic idea is to reduce friction in using this tool by making the "specify an alternative package name" opt-in via optional command line arguments instead of requiring it.

There are two scenarios now that are new from the UX perspective:

1. There already exists a crate with the same name. In that case the rest of the workspace crate creation process will fail and clean up the mess, stating that a package with the given name exists. The user will be able to use the opt-in feature of passing `--name` on the command line to fix that up manually
2. Something else with the name inferring doesn't work out. I'm not even sure if that can be the case anymore, but `file_name` on paths only returns an optional `&str`. In case of a failure there we still use the old behavior of specifying the package name via the command line prompt that was in place beforehand

In any other case the user will just experience less friction which will hopefully improve the user experience.

## Examples:

```
cargo ws create abc
```
the package name is `abc`

---

```
cargo ws create subfolder/def
```
the package name is `def`

---

```
cargo ws create subfolder/abc
```
the package name is also `abc`, hence the user has to pass `--name=SOMETHING` where `SOMETHING` is neither `abc` or `def`