### PR TITLE
Feat/improve init

### DIFF
--- a/cargo-workspaces/Cargo.lock
+++ b/cargo-workspaces/Cargo.lock
@@ -2263,18 +2263,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cargo-workspaces/tests/snapshots/init__normal.snap
+++ b/cargo-workspaces/tests/snapshots/init__normal.snap
@@ -1,6 +1,8 @@
 ---
 source: tests/init.rs
+assertion_line: 26
 expression: err
 ---
+info crates dep1, dep2, top
 info initialized .
 


### PR DESCRIPTION
There are some subtle ways to improve the `init` command.

1. We still rely on manually working on strings to do the member auto detection. 
  - There are better ways to do this in the mean time, namely the `cargo-util-schemas` crate (which we probably want to use in other places as well)
  - I replaced the code working on string with it and ensured to use the `to_pretty_string` serialization method, which will do the same formatting as we tried to achieve manually
2. The workspace init command doesn't set the workspace resolver and doesn't even expose an API to do that as an opt-in
  - I added an optional command line argument `resolver` to pick the resolver version (1 or 2)
  - If no resolver was chosen, it defaults to v2 as it is the newer one
  - The user is informed about the actions taken in both scenarios above (explicit choice or auto choice)