### PR TITLE
Support http.cainfo and some authentication support

### DIFF
--- a/cargo-workspaces/src/publish.rs
+++ b/cargo-workspaces/src/publish.rs
@@ -5,11 +5,16 @@ use crate::utils::{
     Result, VersionOpt, INTERNAL_ERR,
 };
 
+use camino::Utf8PathBuf;
 use cargo_metadata::Metadata;
 use clap::Parser;
 use indexmap::IndexSet as Set;
 use tame_index::{
-    external::reqwest::blocking::Client,
+    external::{
+        gix::filter::plumbing::driver::process::client,
+        http::{HeaderMap, HeaderName, HeaderValue},
+        reqwest::{blocking::Client, header::AUTHORIZATION, Certificate},
+    },
     index::{ComboIndex, ComboIndexCache, RemoteGitIndex, RemoteSparseIndex},
     utils::flock::LockOptions,
     IndexLocation, IndexUrl, KrateName,
@@ -93,6 +98,7 @@ impl Publish {
             })
             .collect::<Set<_>>();
 
+        let http_client = create_http_client(&metadata.workspace_root, &self.token)?;
         for p in &visited {
             let (pkg, version) = names.get(p).expect(INTERNAL_ERR);
             let name = pkg.name.clone();
@@ -114,7 +120,7 @@ impl Publish {
                 IndexUrl::crates_io(None, None, None)?
             };
 
-            if is_published(index_url, &name, version)? {
+            if is_published(&http_client, index_url, &name, version)? {
                 info!("already published", name_ver);
                 continue;
             }
@@ -167,7 +173,27 @@ impl Publish {
     }
 }
 
-fn is_published(index_url: IndexUrl, name: &str, version: &str) -> Result<bool> {
+fn create_http_client(workspace_root: &Utf8PathBuf, token: &Option<String>) -> Result<Client> {
+    let client_builder = Client::builder().use_rustls_tls();
+    let client_builder = if let Some(ref token) = token {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_str(token).unwrap());
+        client_builder.default_headers(headers)
+    } else {
+        client_builder
+    };
+    let http_cainfo = cargo_config_get(workspace_root, "http.cainfo").ok();
+    let client_builder = if let Some(http_cainfo) = http_cainfo {
+        client_builder
+            .tls_built_in_root_certs(false)
+            .add_root_certificate(Certificate::from_pem(&std::fs::read(http_cainfo)?)?)
+    } else {
+        client_builder
+    };
+    Ok(client_builder.build()?)
+}
+
+fn is_published(client: &Client, index_url: IndexUrl, name: &str, version: &str) -> Result<bool> {
     let index_cache = ComboIndexCache::new(IndexLocation::new(index_url))?;
     let lock = LockOptions::cargo_package_lock(None)?.try_lock()?;
 
@@ -178,10 +204,7 @@ fn is_published(index_url: IndexUrl, name: &str, version: &str) -> Result<bool> 
             rgi.fetch(&lock)?;
             rgi.into()
         }
-        ComboIndexCache::Sparse(sparse) => {
-            let client = Client::builder().http2_prior_knowledge().build()?;
-            RemoteSparseIndex::new(sparse, client).into()
-        }
+        ComboIndexCache::Sparse(sparse) => RemoteSparseIndex::new(sparse, client.clone()).into(),
         _ => return Err(Error::UnsupportedCratesIndexType),
     };
 

--- a/cargo-workspaces/src/publish.rs
+++ b/cargo-workspaces/src/publish.rs
@@ -11,8 +11,7 @@ use clap::Parser;
 use indexmap::IndexSet as Set;
 use tame_index::{
     external::{
-        gix::filter::plumbing::driver::process::client,
-        http::{HeaderMap, HeaderName, HeaderValue},
+        http::{HeaderMap, HeaderValue},
         reqwest::{blocking::Client, header::AUTHORIZATION, Certificate},
     },
     index::{ComboIndex, ComboIndexCache, RemoteGitIndex, RemoteSparseIndex},


### PR DESCRIPTION
I use a private Cargo sparse registry. With the last two fixes, more stuff works, but overall there are still problems.

1. The current version asserts HTTP/2 is available. This can't be assumed, as while it's available for crates.io, it's not part of the registry spec. I've increased the scope of connection reuse so there should practically be no additional overhead (and arguably reduced due to fewer TLS handshakes).
1. http.cainfo is the cargo config which is used to set a new CA bundle. We utilise it because our company has its own trust root. This is not picked up by cargo-workspaces, so all commands fail with TLS issues. If this config is set, I've changed the code to configure the client to use it. This requires the use of rustls due to some quirks with reqwest.
1. Sparse registries may require authentication. There doesn't obviously seem to be a way to configure tame index to use this. I've made an assumption that if `--token` is provided, this probably has read access as well as write access and configured it on the reqwest client. Over time, this is likely faulty - with the new Cargo credential helpers it's likely people will move away from using `--token`. However, what we have here is likely good enough for now.