### PR TITLE
fix #153: create command now works with newer cargo versions

### DIFF
--- a/cargo-workspaces/src/create.rs
+++ b/cargo-workspaces/src/create.rs
@@ -177,7 +177,7 @@ impl Create {
             return Err(Error::DuplicatePackageName);
         }
 
-        if !stderr.contains("Created") {
+        if !stderr.contains("Created") && !stderr.contains("Adding") {
             return Err(Error::Create);
         }
 

--- a/cargo-workspaces/src/create.rs
+++ b/cargo-workspaces/src/create.rs
@@ -177,7 +177,7 @@ impl Create {
             return Err(Error::DuplicatePackageName);
         }
 
-        if !stderr.contains("Created") && !stderr.contains("Adding") {
+        if !stderr.contains("Created") && !stderr.contains("Creating") {
             return Err(Error::Create);
         }
 


### PR DESCRIPTION
I am not sure which exact version of cargo this happens on but `create` command fails in cargo 1.78.0 because `Created` is not present in `stderr`. However, `Adding` is present as in this example - 

```text
❯ cargo new --name foo --lib --edition 2021 lib/foo
    Creating library `foo` package
      Adding `foo` as member of workspace at `/home/sushruth/code/moarr`
note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
```

This PR tries to improve that check instead of crashing when there is no issue. (Fix for #153)

I am a beginner to rust so please help me make this fix better.