### PR TITLE
feat: Implement print plan and basic checks for publish command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.5
+
+### Enhancements
+* Allow error on no changes detected
+* List crates to be published
+* Add dry-run mode for publishing
+
 ## 0.3.4
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ But this will also work on single crates because by default every individual cra
       1. [Fixed or Independent](#fixed-or-independent)
    7. [Publish](#publish)
    8. [Rename](#rename)
-   8. [Plan](#plan)
+   9. [Plan](#plan)
 3. [Config](#config)
 4. [Changelog](#changelog)
 
@@ -84,8 +84,10 @@ USAGE:
     cargo workspaces list [OPTIONS]
 
 OPTIONS:
-    -a, --all     Show private crates that are normally hidden
     -h, --help    Print help information
+
+LIST OPTIONS:
+    -a, --all     Show private crates that are normally hidden
         --json    Show information as a JSON array
     -l, --long    Show extended information
 ```
@@ -106,15 +108,17 @@ USAGE:
     cargo workspaces changed [OPTIONS]
 
 OPTIONS:
-    -a, --all                         Show private crates that are normally hidden
         --error-on-empty              Return non-zero exit code if no changes detected
         --force <pattern>             Always include targeted crates matched by glob even when there are no changes
     -h, --help                        Print help information
         --ignore-changes <pattern>    Ignore changes in files matched by glob
         --include-merged-tags         Include tags from merged branches
-        --json                        Show information as a JSON array
-    -l, --long                        Show extended information
         --since <SINCE>               Use this git reference instead of the last tag
+
+LIST OPTIONS:
+    -a, --all     Show private crates that are normally hidden
+        --json    Show information as a JSON array
+    -l, --long    Show extended information
 ```
 
 ### Exec
@@ -217,8 +221,8 @@ OPTIONS:
     -h, --help    Print help information
 
 VERSION ARGS:
-    <BUMP>      Increment all versions by the given explicit semver keyword while skipping the prompts for them [possible values: major, minor, patch,
-                premajor, preminor, prepatch, prerelease, custom]
+    <BUMP>      Increment all versions by the given explicit semver keyword while skipping the prompts for them
+                [possible values: major, minor, patch, premajor, preminor, prepatch, skip, prerelease, custom]
     <CUSTOM>    Specify custom version value when 'bump' is set to 'custom'
 
 VERSION OPTIONS:
@@ -245,12 +249,14 @@ GIT OPTIONS:
 
 PUBLISH OPTIONS:
         --allow-dirty            Allow dirty working directories to be published
+        --dry-run                Perform checks without uploading. WIP and performs fewer checks than `cargo publish --dry-run`
         --no-remove-dev-deps     Don't remove dev-dependencies while publishing
         --no-verify              Skip crate verification (not recommended)
         --publish-as-is          Publish crates from the current commit without versioning
-        --registry <REGISTRY>    The Cargo registry to use for publishing
-        --token <TOKEN>          The token to use for publishing
-        --dry-run                Perform checks without uploading. WIP and performs fewer checks than `cargo publish --dry-run`.
+
+REGISTRY OPTIONS:
+        --registry <REGISTRY>    The Cargo registry to use
+        --token <TOKEN>          The token to use for accessing the registry
 ```
 
 ### Rename
@@ -273,21 +279,23 @@ OPTIONS:
 
 ### Plan
 
-Print the plan for publishing. The output will contain the names and versions of the workspace crates according
-to the order in which they should be published.
+List the crates in publishing order. This does not check for changes or try to version. It takes the crates as-is.
 
 ```
 USAGE:
     cargo workspaces plan [OPTIONS]
 
 OPTIONS:
-    -h, --help
-            Print help information
+    -h, --help              Print help information
+        --skip-published    Skip already published crate versions
 
-PUBLISH PLAN OPTIONS:
-    --check-published        Check if the crates are already published and include the information in the output
-    --registry <REGISTRY>    The Cargo registry to check against
-    --token <TOKEN>          The token to use for accessing the registry
+REGISTRY OPTIONS:
+        --registry <REGISTRY>    The Cargo registry to use
+        --token <TOKEN>          The token to use for accessing the registry
+
+LIST OPTIONS:
+        --json    Show information as a JSON array
+    -l, --long    Show extended information
 ```
 
 ## Config

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ But this will also work on single crates because by default every individual cra
       1. [Fixed or Independent](#fixed-or-independent)
    7. [Publish](#publish)
    8. [Rename](#rename)
+   8. [Plan](#plan)
 3. [Config](#config)
 4. [Changelog](#changelog)
 
@@ -249,6 +250,7 @@ PUBLISH OPTIONS:
         --publish-as-is          Publish crates from the current commit without versioning
         --registry <REGISTRY>    The Cargo registry to use for publishing
         --token <TOKEN>          The token to use for publishing
+        --dry-run                Perform checks without uploading. WIP and performs fewer checks than `cargo publish --dry-run`.
 ```
 
 ### Rename
@@ -267,6 +269,25 @@ OPTIONS:
     -f, --from <crate>        Rename only a specific crate
     -h, --help                Print help information
         --ignore <pattern>    Ignore the crates matched by glob
+```
+
+### Plan
+
+Print the plan for publishing. The output will contain the names and versions of the workspace crates according
+to the order in which they should be published.
+
+```
+USAGE:
+    cargo workspaces plan [OPTIONS]
+
+OPTIONS:
+    -h, --help
+            Print help information
+
+PUBLISH PLAN OPTIONS:
+    --check-published        Check if the crates are already published and include the information in the output
+    --registry <REGISTRY>    The Cargo registry to check against
+    --token <TOKEN>          The token to use for accessing the registry
 ```
 
 ## Config

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ GIT OPTIONS:
 
 PUBLISH OPTIONS:
         --allow-dirty            Allow dirty working directories to be published
-        --dry-run                Perform checks without uploading. WIP and performs fewer checks than `cargo publish --dry-run`
+        --dry-run                Runs in dry-run mode
         --no-remove-dev-deps     Don't remove dev-dependencies while publishing
         --no-verify              Skip crate verification (not recommended)
         --publish-as-is          Publish crates from the current commit without versioning

--- a/cargo-workspaces/Cargo.lock
+++ b/cargo-workspaces/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml_edit 0.19.10",
+ "url",
 ]
 
 [[package]]
@@ -2780,9 +2781,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/cargo-workspaces/Cargo.toml
+++ b/cargo-workspaces/Cargo.toml
@@ -43,6 +43,7 @@ tame-index = { version = "0.9.0", features = ["git", "sparse"] }
 dunce = "1.0.4"
 ctrlc = "3.4.1"
 toml_edit = "0.19.10"
+url = "2.5.2"
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/cargo-workspaces/src/changed.rs
+++ b/cargo-workspaces/src/changed.rs
@@ -58,6 +58,6 @@ impl Changed {
             return Err(Error::NoChanges);
         }
 
-        return Ok(());
+        Ok(())
     }
 }

--- a/cargo-workspaces/src/list.rs
+++ b/cargo-workspaces/src/list.rs
@@ -22,8 +22,7 @@ impl List {
 
         let pkg_ids = visited
             .into_iter()
-            .map(|p| names.get(&p).expect(INTERNAL_ERR).0.id.clone())
-            .collect::<Vec<_>>();
+            .map(|p| names.get(&p).expect(INTERNAL_ERR).0.id.clone());
 
         let pkgs = get_pkgs(&metadata, self.list.all)?;
 

--- a/cargo-workspaces/src/main.rs
+++ b/cargo-workspaces/src/main.rs
@@ -3,6 +3,7 @@ mod create;
 mod exec;
 mod init;
 mod list;
+mod plan;
 mod publish;
 mod rename;
 mod version;
@@ -24,6 +25,7 @@ enum Subcommand {
     Create(create::Create),
     Rename(rename::Rename),
     Init(init::Init),
+    Plan(plan::Plan),
 }
 
 #[derive(Debug, Parser)]
@@ -83,6 +85,7 @@ fn main() {
             Subcommand::Exec(x) => x.run(metadata),
             Subcommand::Create(x) => x.run(metadata),
             Subcommand::Rename(x) => x.run(metadata),
+            Subcommand::Plan(x) => x.run(metadata),
             _ => unreachable!(),
         }
     };

--- a/cargo-workspaces/src/plan.rs
+++ b/cargo-workspaces/src/plan.rs
@@ -1,0 +1,65 @@
+use crate::utils::{
+    create_http_client, dag, filter_private, info, is_published, package_registry, Result,
+    INTERNAL_ERR,
+};
+
+use cargo_metadata::Metadata;
+use clap::Parser;
+
+/// Prepare a plan for publishing crates in the project
+#[derive(Debug, Parser)]
+#[clap(next_help_heading = "PUBLISH PLAN OPTIONS")]
+pub struct Plan {
+    /// The token to use for accessing the registry
+    #[clap(long, forbid_empty_values(true))]
+    token: Option<String>,
+
+    /// The Cargo registry to check against
+    #[clap(long, forbid_empty_values(true))]
+    registry: Option<String>,
+
+    /// Check if the crates are already published.
+    #[clap(long, short)]
+    check_published: bool,
+}
+
+impl Plan {
+    pub fn run(self, metadata: Metadata) -> Result {
+        let pkgs: Vec<_> = metadata
+            .packages
+            .iter()
+            .map(|x| (x.clone(), x.version.to_string()))
+            .collect();
+
+        let (names, visited) = dag(&pkgs);
+
+        // Filter out private packages
+        let visited = filter_private(visited, &pkgs);
+
+        let http_client = create_http_client(&metadata.workspace_root, &self.token)?;
+        for p in &visited {
+            let (pkg, version) = names.get(p).expect(INTERNAL_ERR);
+            let name = pkg.name.clone();
+
+            let name_ver = format!("{} v{}", name, version);
+
+            let index_url = package_registry(&metadata, self.registry.as_ref(), pkg)?;
+
+            let already_published = if self.check_published {
+                is_published(&http_client, index_url, &name, version)?
+            } else {
+                false
+            };
+
+            let msg = if already_published {
+                format!("{name_ver} (already published)")
+            } else {
+                name_ver
+            };
+            info!("- ", msg);
+        }
+
+        info!("success", "ok");
+        Ok(())
+    }
+}

--- a/cargo-workspaces/src/publish.rs
+++ b/cargo-workspaces/src/publish.rs
@@ -1,23 +1,13 @@
-use std::convert::TryFrom;
-
 use crate::utils::{
-    cargo, cargo_config_get, dag, info, should_remove_dev_deps, warn, DevDependencyRemover, Error,
-    Result, VersionOpt, INTERNAL_ERR,
+    basic_checks, cargo, cargo_config_get, create_http_client, dag, filter_private, info,
+    is_published, should_remove_dev_deps, warn, DevDependencyRemover, Error, Result, VersionOpt,
+    INTERNAL_ERR,
 };
 
 use camino::Utf8PathBuf;
 use cargo_metadata::Metadata;
 use clap::Parser;
-use indexmap::IndexSet as Set;
-use tame_index::{
-    external::{
-        http::{HeaderMap, HeaderValue},
-        reqwest::{blocking::Client, header::AUTHORIZATION, Certificate},
-    },
-    index::{ComboIndex, ComboIndexCache, RemoteGitIndex, RemoteSparseIndex},
-    utils::flock::LockOptions,
-    IndexLocation, IndexUrl, KrateName,
-};
+use tame_index::IndexUrl;
 
 /// Publish crates in the project
 #[derive(Debug, Parser)]
@@ -54,10 +44,27 @@ pub struct Publish {
     /// Don't remove dev-dependencies while publishing
     #[clap(long)]
     no_remove_dev_deps: bool,
+
+    /// Perform checks without uploading. WIP and performs fewer
+    /// checks than `cargo publish --dry-run`
+    #[clap(long)]
+    dry_run: bool,
 }
 
 impl Publish {
-    pub fn run(self, metadata: Metadata) -> Result {
+    pub fn run(mut self, metadata: Metadata) -> Result {
+        if self.dry_run {
+            warn!(
+                "Dry run option is WIP and performs fewer checks than `cargo publish --dry-run`.",
+                ""
+            );
+            if !self.publish_as_is {
+                info!("Dry run doesn't perform versioning. Perform `version` command manually if required", "");
+                info!("Skipping versioning step", "");
+                self.publish_as_is = true;
+            }
+        }
+
         let pkgs = if !self.publish_as_is {
             self.version
                 .do_versioning(&metadata)?
@@ -85,23 +92,26 @@ impl Publish {
         let (names, visited) = dag(&pkgs);
 
         // Filter out private packages
-        let visited = visited
-            .into_iter()
-            .filter(|x| {
-                if let Some((pkg, _)) = pkgs.iter().find(|(p, _)| p.manifest_path == *x) {
-                    return pkg.publish.is_none()
-                        || !pkg.publish.as_ref().expect(INTERNAL_ERR).is_empty();
-                }
-
-                false
-            })
-            .collect::<Set<_>>();
+        let visited = filter_private(visited, &pkgs);
 
         let http_client = create_http_client(&metadata.workspace_root, &self.token)?;
 
         for p in &visited {
             let (pkg, version) = names.get(p).expect(INTERNAL_ERR);
             let name = pkg.name.clone();
+
+            if self.dry_run {
+                info!("Checking package", name);
+                if !self.no_verify {
+                    self.try_build(&metadata.workspace_root, &name, p)?;
+                } else {
+                    info!("Skipping build", name);
+                }
+                basic_checks(pkg)?;
+                info!("Can be published", name);
+                continue;
+            }
+
             let mut args = vec!["publish"];
 
             let name_ver = format!("{} v{}", name, version);
@@ -171,48 +181,21 @@ impl Publish {
         info!("success", "ok");
         Ok(())
     }
-}
 
-fn create_http_client(workspace_root: &Utf8PathBuf, token: &Option<String>) -> Result<Client> {
-    let client_builder = Client::builder().use_rustls_tls();
-    let client_builder = if let Some(ref token) = token {
-        let mut headers = HeaderMap::new();
-        headers.insert(AUTHORIZATION, HeaderValue::from_str(token).unwrap());
-        client_builder.default_headers(headers)
-    } else {
-        client_builder
-    };
-    let http_cainfo = cargo_config_get(workspace_root, "http.cainfo").ok();
-    let client_builder = if let Some(http_cainfo) = http_cainfo {
-        client_builder
-            .tls_built_in_root_certs(false)
-            .add_root_certificate(Certificate::from_pem(&std::fs::read(http_cainfo)?)?)
-    } else {
-        client_builder
-    };
-    Ok(client_builder.build()?)
-}
+    fn try_build(
+        &self,
+        workspace_root: &Utf8PathBuf,
+        name: &str,
+        manifest_path: &Utf8PathBuf,
+    ) -> Result<()> {
+        let mut args = vec!["build"];
+        args.push("--manifest-path");
+        args.push(manifest_path.as_str());
 
-fn is_published(client: &Client, index_url: IndexUrl, name: &str, version: &str) -> Result<bool> {
-    let index_cache = ComboIndexCache::new(IndexLocation::new(index_url))?;
-    let lock = LockOptions::cargo_package_lock(None)?.try_lock()?;
-
-    let index: ComboIndex = match index_cache {
-        ComboIndexCache::Git(git) => {
-            let mut rgi = RemoteGitIndex::new(git, &lock)?;
-
-            rgi.fetch(&lock)?;
-            rgi.into()
+        let (_stdout, stderr) = cargo(workspace_root, &args, &[])?;
+        if stderr.contains("could not compile") {
+            return Err(Error::Build(name.to_string()));
         }
-        ComboIndexCache::Sparse(sparse) => RemoteSparseIndex::new(sparse, client.clone()).into(),
-        _ => return Err(Error::UnsupportedCratesIndexType),
-    };
-
-    if let Some(crate_data) = index.krate(KrateName::try_from(name)?, false, &lock)? {
-        if crate_data.versions.iter().any(|v| v.version == version) {
-            return Ok(true);
-        }
+        Ok(())
     }
-
-    Ok(false)
 }

--- a/cargo-workspaces/src/utils/basic_checks.rs
+++ b/cargo-workspaces/src/utils/basic_checks.rs
@@ -1,6 +1,7 @@
+use cargo_metadata::Package;
 use url::Url;
 
-use crate::utils::{warn, Error, Result};
+use crate::utils::{warn, Result};
 
 /// Performs basic checks to make sure that crate can be published.
 /// Returns `Ok(())` if no problems were found, otherwise returns a list of
@@ -12,7 +13,7 @@ use crate::utils::{warn, Error, Result};
 /// Current list of checks is based on the [cargo reference recommendations][1].
 ///
 /// [1]: https://doc.rust-lang.org/cargo/reference/publishing.html#before-publishing-a-new-crate
-pub fn basic_checks(pkg: &cargo_metadata::Package) -> Result<()> {
+pub fn basic_checks(pkg: &Package) -> Result {
     let mut problems = Vec::new();
 
     // Mandatory fields.
@@ -64,16 +65,11 @@ pub fn basic_checks(pkg: &cargo_metadata::Package) -> Result<()> {
         }
     }
 
-    if problems.is_empty() {
-        Ok(())
-    } else {
-        let name = pkg.name.clone();
-        warn!("  basic checks failed", name);
-        for problem in problems {
-            warn!("  - {}", problem);
-        }
-        Err(Error::Publish(name))
+    for problem in problems {
+        warn!("check failed", problem);
     }
+
+    Ok(())
 }
 
 // Adapted from:

--- a/cargo-workspaces/src/utils/basic_checks.rs
+++ b/cargo-workspaces/src/utils/basic_checks.rs
@@ -1,0 +1,110 @@
+use url::Url;
+
+use crate::utils::{warn, Error, Result};
+
+/// Performs basic checks to make sure that crate can be published.
+/// Returns `Ok(())` if no problems were found, otherwise returns a list of
+/// strings, each describing a problem.
+///
+/// This method is a simple heuristic, and if it returns `Ok(())`, it does not
+/// guarantee that the crate can be published successfully.
+///
+/// Current list of checks is based on the [cargo reference recommendations][1].
+///
+/// [1]: https://doc.rust-lang.org/cargo/reference/publishing.html#before-publishing-a-new-crate
+pub fn basic_checks(pkg: &cargo_metadata::Package) -> Result<()> {
+    let mut problems = Vec::new();
+
+    // Mandatory fields.
+    if pkg.description.is_none() {
+        problems.push("'description' field should be set".to_string());
+    }
+    if pkg.license.is_none() && pkg.license_file.is_none() {
+        problems.push("either 'license' or 'license-file' field should be set".to_string());
+    }
+
+    // Too long description.
+    const MAX_DESCRIPTION_LEN: usize = 1000;
+    if pkg
+        .description
+        .as_ref()
+        .map(|d| d.len() > MAX_DESCRIPTION_LEN)
+        .unwrap_or(false)
+    {
+        problems.push(format!(
+            "Description is too long (max {} characters)",
+            MAX_DESCRIPTION_LEN
+        ));
+    }
+
+    // URLs must be valid.
+    validate_url(&pkg.homepage.as_deref(), "homepage", &mut problems);
+    validate_url(
+        &pkg.documentation.as_deref(),
+        "documentation",
+        &mut problems,
+    );
+    validate_url(&pkg.repository.as_deref(), "repository", &mut problems);
+
+    // Keywords limit and size
+    const MAX_KEYWORDS: usize = 5;
+    if pkg.keywords.len() > MAX_KEYWORDS {
+        problems.push(format!("Too many keywords (max {} keywords)", MAX_KEYWORDS));
+    }
+
+    const MAX_KEYWORD_LEN: usize = 20;
+    for kw in pkg.keywords.iter() {
+        if kw.len() > MAX_KEYWORD_LEN {
+            problems.push(format!(
+                "Keyword is too long (max {} characters): {}",
+                MAX_KEYWORD_LEN, kw
+            ));
+        } else if !valid_keyword(kw) {
+            problems.push(format!("Keyword contains invalid characters: {}", kw));
+        }
+    }
+
+    if problems.is_empty() {
+        Ok(())
+    } else {
+        let name = pkg.name.clone();
+        warn!("  basic checks failed", name);
+        for problem in problems {
+            warn!("  - {}", problem);
+        }
+        Err(Error::Publish(name))
+    }
+}
+
+// Adapted from:
+// https://github.com/rust-lang/crates.io/blob/d507a12560ab923c2a1a061e5365fe6b1f1293a8/src/models/keyword.rs#L56
+fn valid_keyword(keyword: &str) -> bool {
+    let mut chars = keyword.chars();
+    let first = match chars.next() {
+        None => return false,
+        Some(c) => c,
+    };
+    first.is_ascii_alphanumeric()
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+')
+}
+
+// Adapted from:
+// https://github.com/rust-lang/crates.io/blob/d507a12560ab923c2a1a061e5365fe6b1f1293a8/src/controllers/krate/publish.rs#L233
+fn validate_url(url: &Option<&str>, field: &str, problems: &mut Vec<String>) {
+    let Some(url) = url else {
+        return;
+    };
+
+    // Manually check the string, as `Url::parse` may normalize relative URLs
+    // making it difficult to ensure that both slashes are present.
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        problems.push(format!(
+            "URL for field `{field}` must begin with http:// or https:// (url: {url})"
+        ));
+    }
+
+    // Ensure the entire URL parses as well
+    if Url::parse(url).is_err() {
+        problems.push(format!("`{field}` is not a valid url: `{url}`"));
+    }
+}

--- a/cargo-workspaces/src/utils/cargo.rs
+++ b/cargo-workspaces/src/utils/cargo.rs
@@ -198,7 +198,7 @@ fn edit_version(
     versions: &Map<String, Version>,
     exact: bool,
     version_index: usize,
-) -> Result<()> {
+) -> Result {
     if let Some(new_version) = versions.get(&caps[version_index]) {
         if exact {
             new_lines.push(format!("{}={}{}", &caps[1], new_version, &caps[4]));
@@ -215,7 +215,7 @@ fn rename_dep(
     new_lines: &mut Vec<String>,
     renames: &Map<String, String>,
     name_index: usize,
-) -> Result<()> {
+) -> Result {
     if let Some(new_name) = renames.get(&caps[name_index]) {
         new_lines.push(format!("{}{}{}", &caps[1], new_name, &caps[3]));
     }

--- a/cargo-workspaces/src/utils/error.rs
+++ b/cargo-workspaces/src/utils/error.rs
@@ -76,6 +76,8 @@ pub enum Error {
     #[error("command needs to be run from the workspace root")]
     MustBeRunFromWorkspaceRoot,
 
+    #[error("unable to build package {0}")]
+    Build(String),
     #[error("unable to verify package {0}")]
     Verify(String),
     #[error("unable to publish package {0}")]

--- a/cargo-workspaces/src/utils/error.rs
+++ b/cargo-workspaces/src/utils/error.rs
@@ -76,8 +76,6 @@ pub enum Error {
     #[error("command needs to be run from the workspace root")]
     MustBeRunFromWorkspaceRoot,
 
-    #[error("unable to build package {0}")]
-    Build(String),
     #[error("unable to verify package {0}")]
     Verify(String),
     #[error("unable to publish package {0}")]

--- a/cargo-workspaces/src/utils/mod.rs
+++ b/cargo-workspaces/src/utils/mod.rs
@@ -20,9 +20,11 @@ pub use dev_dep_remover::{should_remove_dev_deps, DevDependencyRemover};
 pub(crate) use error::{debug, info, warn};
 pub use error::{get_debug, set_debug, Error};
 pub use git::{git, GitOpt};
-pub use list::{list, ListOpt};
+pub use list::{list, ListOpt, ListPublicOpt};
 pub use pkg::{get_pkgs, is_private, Pkg};
-pub use publish::{create_http_client, filter_private, is_published, package_registry};
+pub use publish::{
+    create_http_client, filter_private, is_published, package_registry, RegistryOpt,
+};
 pub use version::VersionOpt;
 
 pub type Result<T = ()> = std::result::Result<T, Error>;

--- a/cargo-workspaces/src/utils/mod.rs
+++ b/cargo-workspaces/src/utils/mod.rs
@@ -1,3 +1,4 @@
+mod basic_checks;
 mod cargo;
 mod changable;
 mod config;
@@ -7,8 +8,10 @@ mod error;
 mod git;
 mod list;
 mod pkg;
+mod publish;
 mod version;
 
+pub use basic_checks::basic_checks;
 pub use cargo::{cargo, cargo_config_get, change_versions, rename_packages};
 pub use changable::{ChangeData, ChangeOpt};
 pub use config::{read_config, PackageConfig, WorkspaceConfig};
@@ -19,6 +22,7 @@ pub use error::{get_debug, set_debug, Error};
 pub use git::{git, GitOpt};
 pub use list::{list, ListOpt};
 pub use pkg::{get_pkgs, is_private, Pkg};
+pub use publish::{create_http_client, filter_private, is_published, package_registry};
 pub use version::VersionOpt;
 
 pub type Result<T = ()> = std::result::Result<T, Error>;

--- a/cargo-workspaces/src/utils/publish.rs
+++ b/cargo-workspaces/src/utils/publish.rs
@@ -1,0 +1,100 @@
+//! Helper functions useful when publishing (or preparing for publishing) crates.
+
+use std::convert::TryFrom;
+
+use crate::utils::{cargo_config_get, Error, Result, INTERNAL_ERR};
+
+use camino::Utf8PathBuf;
+use cargo_metadata::{Metadata, Package};
+use indexmap::IndexSet as Set;
+use tame_index::{
+    external::{
+        http::{HeaderMap, HeaderValue},
+        reqwest::{blocking::Client, header::AUTHORIZATION, Certificate},
+    },
+    index::{ComboIndex, ComboIndexCache, RemoteGitIndex, RemoteSparseIndex},
+    utils::flock::LockOptions,
+    IndexLocation, IndexUrl, KrateName,
+};
+
+pub fn filter_private(visited: Set<Utf8PathBuf>, pkgs: &[(Package, String)]) -> Set<Utf8PathBuf> {
+    visited
+        .into_iter()
+        .filter(|x| {
+            if let Some((pkg, _)) = pkgs.iter().find(|(p, _)| p.manifest_path == *x) {
+                return pkg.publish.is_none()
+                    || !pkg.publish.as_ref().expect(INTERNAL_ERR).is_empty();
+            }
+
+            false
+        })
+        .collect()
+}
+
+pub fn package_registry<'a>(
+    metadata: &Metadata,
+    registry: Option<&'a String>,
+    pkg: &Package,
+) -> Result<IndexUrl<'a>> {
+    let url = if let Some(registry) =
+        registry.or_else(|| pkg.publish.as_deref().and_then(|x| x.get(0)))
+    {
+        let registry_url = cargo_config_get(
+            &metadata.workspace_root,
+            &format!("registries.{}.index", registry),
+        )?;
+        IndexUrl::NonCratesIo(registry_url.into())
+    } else {
+        IndexUrl::crates_io(None, None, None)?
+    };
+    Ok(url)
+}
+
+pub fn create_http_client(workspace_root: &Utf8PathBuf, token: &Option<String>) -> Result<Client> {
+    let client_builder = Client::builder().use_rustls_tls();
+    let client_builder = if let Some(ref token) = token {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_str(token).unwrap());
+        client_builder.default_headers(headers)
+    } else {
+        client_builder
+    };
+    let http_cainfo = cargo_config_get(workspace_root, "http.cainfo").ok();
+    let client_builder = if let Some(http_cainfo) = http_cainfo {
+        client_builder
+            .tls_built_in_root_certs(false)
+            .add_root_certificate(Certificate::from_pem(&std::fs::read(http_cainfo)?)?)
+    } else {
+        client_builder
+    };
+    Ok(client_builder.build()?)
+}
+
+pub fn is_published(
+    client: &Client,
+    index_url: IndexUrl,
+    name: &str,
+    version: &str,
+) -> Result<bool> {
+    let index_cache = ComboIndexCache::new(IndexLocation::new(index_url))?;
+    let lock = LockOptions::cargo_package_lock(None)?.try_lock()?;
+
+    let index: ComboIndex = match index_cache {
+        ComboIndexCache::Git(git) => {
+            let mut rgi = RemoteGitIndex::new(git, &lock)?;
+
+            rgi.fetch(&lock)?;
+            rgi.into()
+        }
+        ComboIndexCache::Sparse(sparse) => RemoteSparseIndex::new(sparse, client.clone()).into(),
+        _ => return Err(Error::UnsupportedCratesIndexType),
+    };
+
+    if let Some(crate_data) = index.krate(KrateName::try_from(name)?, false, &lock)? {
+        if crate_data.versions.iter().any(|v| v.version == version) {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}


### PR DESCRIPTION
This PR adds two features I found useful recently:

- Ability to perform basic checks before running `cargo publish`.
- Ability to just print the packages in order in which they should be published.

The first one proved handy when I had to publish a lot of crates written by different people that weren't initially meant to be published. So every so often a field would be forgotten, but I won't know about it until I'm in the middle of the publishing process.

The second one is useful for large workspaces: crates.io has pretty strict rate limits on publishing new packages, so it's actually easier to get the order in which crates should be published and then do it manually.