### PR TITLE
Exit on ctrl+c

### DIFF
--- a/cargo-workspaces/src/main.rs
+++ b/cargo-workspaces/src/main.rs
@@ -98,6 +98,8 @@ fn set_handlers() {
     ctrlc::set_handler(move || {
         let term = dialoguer::console::Term::stdout();
         let _ = term.show_cursor();
+        // Mimic normal `Ctrl-C` exit code.
+        std::process::exit(130);
     })
     .expect("Error setting Ctrl-C handler");
 }


### PR DESCRIPTION
`cargo-workspaces` sets the `ctrl+c` handler that doesn't terminate the program. When working with large workspaces, I find myself having to kill it with sigterm instead of sigint. This PR fixes it.

Before:

```
$ cargo ws plan --skip-published
error: config value `http.cainfo` is not set
^C^C^C^C^C^C^C^C
[1]    8534 terminated  cargo ws plan --skip-published
```

After:

```
$ cargo ws plan --skip-published
error: config value `http.cainfo` is not set
^C%
```