### PR TITLE
Implement owner subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ But this will also work on single crates because by default every individual cra
    7. [Publish](#publish)
    8. [Rename](#rename)
    9. [Plan](#plan)
+   10. [Owner](#owner)
 3. [Config](#config)
 4. [Changelog](#changelog)
 
@@ -296,6 +297,27 @@ REGISTRY OPTIONS:
 LIST OPTIONS:
         --json    Show information as a JSON array
     -l, --long    Show extended information
+```
+
+### Owner
+
+Manage the owners of the workspaces crates.
+
+```
+USAGE:
+    cargo workspaces owner [OPTIONS]
+
+OPTIONS:
+    -h, --help    Print help information
+
+OWNER OPTIONS:
+    -a, --add <ADD>          Name of a user or team to invite as an owner
+    -l, --list               List owners for each crate in the workspace
+    -r, --remove <REMOVE>    Name of a user or team to remove as an owner
+
+REGISTRY OPTIONS:
+        --registry <REGISTRY>    The Cargo registry to use
+        --token <TOKEN>          The token to use for accessing the registry
 ```
 
 ## Config

--- a/cargo-workspaces/src/main.rs
+++ b/cargo-workspaces/src/main.rs
@@ -3,6 +3,7 @@ mod create;
 mod exec;
 mod init;
 mod list;
+mod owner;
 mod plan;
 mod publish;
 mod rename;
@@ -26,6 +27,7 @@ enum Subcommand {
     Rename(rename::Rename),
     Init(init::Init),
     Plan(plan::Plan),
+    Owner(owner::Owner),
 }
 
 #[derive(Debug, Parser)]
@@ -86,6 +88,7 @@ fn main() {
             Subcommand::Create(x) => x.run(metadata),
             Subcommand::Rename(x) => x.run(metadata),
             Subcommand::Plan(x) => x.run(metadata),
+            Subcommand::Owner(x) => x.run(metadata),
             _ => unreachable!(),
         }
     };

--- a/cargo-workspaces/src/owner.rs
+++ b/cargo-workspaces/src/owner.rs
@@ -1,0 +1,83 @@
+use crate::utils::{cargo, dag, filter_private, info, Error, RegistryOpt, Result, INTERNAL_ERR};
+
+use cargo_metadata::Metadata;
+use clap::Parser;
+
+/// Manage the owners of the workspaces crates
+#[derive(Debug, Parser)]
+#[clap(next_help_heading = "OWNER OPTIONS")]
+pub struct Owner {
+    /// Name of a user or team to invite as an owner
+    #[clap(short, long)]
+    add: Option<String>,
+
+    /// Name of a user or team to remove as an owner
+    #[clap(short, long)]
+    remove: Option<String>,
+
+    /// List owners for each crate in the workspace
+    #[clap(short, long)]
+    list: bool,
+
+    #[clap(flatten)]
+    registry: RegistryOpt,
+}
+
+impl Owner {
+    pub fn run(self, metadata: Metadata) -> Result {
+        let pkgs = metadata
+            .packages
+            .iter()
+            .map(|x| (x.clone(), x.version.to_string()))
+            .collect::<Vec<_>>();
+
+        let (names, visited) = dag(&pkgs);
+
+        // Filter out private packages
+        let visited = filter_private(visited, &pkgs);
+
+        for p in &visited {
+            let (pkg, _version) = names.get(p).expect(INTERNAL_ERR);
+            let name = pkg.name.clone();
+
+            let mut args = vec!["owner"];
+
+            if let Some(ref registry) = self.registry.registry {
+                args.push("--registry");
+                args.push(registry);
+            }
+
+            if let Some(ref token) = self.registry.token {
+                args.push("--token");
+                args.push(token);
+            }
+
+            if let Some(ref add) = self.add {
+                args.push("--add");
+                args.push(add);
+            }
+
+            if let Some(ref remove) = self.remove {
+                args.push("--remove");
+                args.push(remove);
+            }
+
+            if self.list {
+                args.push("--list");
+            }
+
+            // `cargo owner` doesn't support `manifest-path`
+            let crate_path = pkg.manifest_path.parent().expect(INTERNAL_ERR);
+
+            let (stdout, stderr) = cargo(crate_path, &args, &[])?;
+            // `cargo owner` uses `stdout` to print the names.
+            eprintln!("{}", stdout);
+            if stderr.contains("error:") {
+                return Err(Error::Owner(name));
+            }
+        }
+
+        info!("success", "ok");
+        Ok(())
+    }
+}

--- a/cargo-workspaces/src/utils/error.rs
+++ b/cargo-workspaces/src/utils/error.rs
@@ -83,6 +83,9 @@ pub enum Error {
     #[error("unable to update Cargo.lock")]
     Update,
 
+    #[error("unable to modify owners for package {0}")]
+    Owner(String),
+
     #[error("{0} value must contain '%n'")]
     MustContainPercentN(String),
 


### PR DESCRIPTION
`cargo owner`, but for workspaces.
The implementation is straightforward, it simply executes `cargo owner` for each package.

Initially, I've added a test for `cargo ws owner --list`, but turns out that any `cargo owner` command requires a token to be present (see [this workflow failure](https://github.com/pksunkara/cargo-workspaces/actions/runs/9970630578/job/27549952934?pr=159#step:5:640)), so I removed it.