### PR TITLE
Bump MSRV to 1.78

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install rust
-        uses: dtolnay/rust-toolchain@1.70.0
+        uses: dtolnay/rust-toolchain@1.78.0
         with:
           targets: ${{ matrix.target }}
       - name: Install linker
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install rust
-        uses: dtolnay/rust-toolchain@1.70.0
+        uses: dtolnay/rust-toolchain@1.78.0
         with:
           components: rustfmt, clippy
       - name: Lint check
@@ -83,6 +83,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install rust
-        uses: dtolnay/rust-toolchain@1.70.0
+        uses: dtolnay/rust-toolchain@1.78.0
       - name: Lockfile check
         run: cargo update -w --locked --manifest-path cargo-workspaces/Cargo.toml

--- a/cargo-workspaces/Cargo.toml
+++ b/cargo-workspaces/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/pksunkara/cargo-workspaces"
 license = "MIT"
 readme = "README.md"
 exclude = ["tests"]
-rust-version = "1.70.0"
+rust-version = "1.78"
 default-run = "cargo-workspaces"
 
 [[bin]]

--- a/cargo-workspaces/src/exec.rs
+++ b/cargo-workspaces/src/exec.rs
@@ -60,7 +60,7 @@ impl Exec {
                 .parent()
                 .ok_or_else(|| Error::ManifestHasNoParent(pkg.name.clone()))?;
 
-            let status = Command::new(self.args.get(0).expect(INTERNAL_ERR))
+            let status = Command::new(self.args.first().expect(INTERNAL_ERR))
                 .args(&self.args[1..])
                 .current_dir(dir)
                 .status()?;

--- a/cargo-workspaces/src/utils/publish.rs
+++ b/cargo-workspaces/src/utils/publish.rs
@@ -48,7 +48,7 @@ pub fn package_registry<'a>(
     pkg: &Package,
 ) -> Result<IndexUrl<'a>> {
     let url = if let Some(registry) =
-        registry.or_else(|| pkg.publish.as_deref().and_then(|x| x.get(0)))
+        registry.or_else(|| pkg.publish.as_deref().and_then(|x| x.first()))
     {
         let registry_url = cargo_config_get(
             &metadata.workspace_root,

--- a/cargo-workspaces/src/utils/version.rs
+++ b/cargo-workspaces/src/utils/version.rs
@@ -129,10 +129,10 @@ impl VersionOpt {
         let new_versions = self.confirm_versions(new_versions)?;
 
         for p in &metadata.packages {
-            if new_versions.get(&p.name).is_none()
+            if new_versions.contains_key(&p.name)
                 && p.dependencies
                     .iter()
-                    .all(|x| new_versions.get(&x.name).is_none())
+                    .all(|x| new_versions.contains_key(&x.name))
             {
                 continue;
             }
@@ -345,7 +345,7 @@ impl VersionOpt {
 }
 
 fn inc_pre(pre: &[Identifier], preid: &Option<String>) -> Vec<Identifier> {
-    match pre.get(0) {
+    match pre.first() {
         Some(Identifier::AlphaNumeric(id)) => {
             vec![Identifier::AlphaNumeric(id.clone()), Identifier::Numeric(0)]
         }
@@ -368,7 +368,7 @@ fn inc_preid(cur_version: &Version, preid: Identifier) -> Version {
         version.increment_patch();
         version.pre = vec![preid, Identifier::Numeric(0)];
     } else {
-        match cur_version.pre.get(0).expect(INTERNAL_ERR) {
+        match cur_version.pre.first().expect(INTERNAL_ERR) {
             Identifier::AlphaNumeric(id) => {
                 version.pre = vec![preid.clone()];
 
@@ -385,7 +385,7 @@ fn inc_preid(cur_version: &Version, preid: Identifier) -> Version {
             }
             Identifier::Numeric(n) => {
                 if preid.to_string() == n.to_string() {
-                    version.pre = cur_version.pre.clone();
+                    version.pre.clone_from(&cur_version.pre);
 
                     if let Some(Identifier::Numeric(n)) = version
                         .pre
@@ -405,7 +405,7 @@ fn inc_preid(cur_version: &Version, preid: Identifier) -> Version {
 }
 
 fn custom_pre(cur_version: &Version) -> (Identifier, Version) {
-    let id = if let Some(id) = cur_version.pre.get(0) {
+    let id = if let Some(id) = cur_version.pre.first() {
         id.clone()
     } else {
         Identifier::AlphaNumeric("alpha".to_string())

--- a/cargo-workspaces/tests/snapshots/create__create_bin_2015.snap
+++ b/cargo-workspaces/tests/snapshots/create__create_bin_2015.snap
@@ -8,6 +8,4 @@ name = "mynewcrate-bin-2015"
 version = "0.0.0"
 edition = "2015"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/cargo-workspaces/tests/snapshots/create__create_bin_2018.snap
+++ b/cargo-workspaces/tests/snapshots/create__create_bin_2018.snap
@@ -8,6 +8,4 @@ name = "mynewcrate-bin-2018"
 version = "0.0.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/cargo-workspaces/tests/snapshots/create__create_lib_2015.snap
+++ b/cargo-workspaces/tests/snapshots/create__create_lib_2015.snap
@@ -8,6 +8,4 @@ name = "mynewcrate-lib-2015"
 version = "0.0.0"
 edition = "2015"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/cargo-workspaces/tests/snapshots/create__create_lib_2018.snap
+++ b/cargo-workspaces/tests/snapshots/create__create_lib_2018.snap
@@ -8,6 +8,4 @@ name = "mynewcrate-lib-2018"
 version = "0.0.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/cargo-workspaces/tests/snapshots/create__member_glob.snap
+++ b/cargo-workspaces/tests/snapshots/create__member_glob.snap
@@ -8,6 +8,4 @@ name = "dep3"
 version = "0.0.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]


### PR DESCRIPTION
Bumps MSRV to ~~1.79~~ 1.78. Two reasons:

1. 1.70 is too old, and [CI is broken](https://github.com/pksunkara/cargo-workspaces/actions/runs/10291338462/job/28483357538#step:5:268). At least 1.74 is required.
2. Output of `cargo` has changed, and it's better for tests to reflect the current state of affairs.

Changes were introduced in 1.78
Also fixes newly added clippy lints.