### PR TITLE
Fix workspace crate not in index error

### DIFF
--- a/cargo-workspaces/src/utils/publish.rs
+++ b/cargo-workspaces/src/utils/publish.rs
@@ -102,11 +102,10 @@ pub fn is_published(
         _ => return Err(Error::UnsupportedCratesIndexType),
     };
 
-    if let Some(crate_data) = index.krate(KrateName::try_from(name)?, false, &lock)? {
-        if crate_data.versions.iter().any(|v| v.version == version) {
-            return Ok(true);
-        }
+    let index_crate = index.krate(KrateName::try_from(name)?, false, &lock);
+    match index_crate {
+        Ok(Some(crate_data)) => Ok(crate_data.versions.iter().any(|v| v.version == version)),
+        Ok(None) | Err(tame_index::Error::NoCrateVersions) => Ok(false),
+        Err(e) => Err(e.into()),
     }
-
-    Ok(false)
 }


### PR DESCRIPTION
I added a handler for tame_index::Error::NoCrateVersions, which raised the following error upon running `cargo workspaces publish` to an Azure Devops Artefacts registry when one of the workspace crates has not yet been published:: 
`error: crates index error: index entry contained no versions for the crate`

The proposed change results in an unpublished return value in the `is_published` function instead of an error. Publishing afterward is successful.

Tested successfully using  
`cargo workspaces publish --registry <...> --yes --all patch  --no-git-commit --token "$PAT"`

