### PR TITLE
feat: Add --publish-interval option and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added support for `2024` edition when creating package
 * Added `locked` flag to `publish` subcommand
 * Added `since` flag to `version` & `publish` subcommands
+* Added `publish-interval` flag to `publish` subcommand
 
 ### Bug Fixes
 * Fixes issue with first publish to custom registries

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Publish all the crates from the workspace in the correct order according to the 
 this command runs [version](#version) first. If you do not want that to happen, you can supply the
 `--from-git` option.
 
+To avoid potential rate-limiting by the registry when publishing many crates, you can use the `--publish-interval <SECONDS>` option. For example, `cargo workspaces publish --publish-interval 10` will wait 10 seconds between each crate publication.
+
 > Note: dev-dependencies are not taken into account when building the dependency
 > graph used to determine the proper publishing order. This is because
 > dev-dependencies are ignored by `cargo publish` - as such, a dev-dependency on a
@@ -247,12 +249,13 @@ GIT OPTIONS:
         --tag-prefix <PREFIX>               Customize tag prefix (can be empty) [default: v]
 
 PUBLISH OPTIONS:
-        --allow-dirty           Allow dirty working directories to be published
-        --dry-run               Runs in dry-run mode
-        --locked                Assert that `Cargo.lock` will remain unchanged
-        --no-remove-dev-deps    Don't remove dev-dependencies while publishing
-        --no-verify             Skip crate verification (not recommended)
-        --publish-as-is         Publish crates from the current commit without versioning
+        --allow-dirty                   Allow dirty working directories to be published
+        --dry-run                       Runs in dry-run mode
+        --locked                        Assert that `Cargo.lock` will remain unchanged
+        --no-remove-dev-deps            Don't remove dev-dependencies while publishing
+        --no-verify                     Skip crate verification (not recommended)
+        --publish-as-is                 Publish crates from the current commit without versioning
+        --publish-interval <SECONDS>    Number of seconds to wait between publish attempt
 
 REGISTRY OPTIONS:
         --registry <REGISTRY>    The Cargo registry to use


### PR DESCRIPTION
This commit introduces a new command-line option `--publish-interval` to the `publish` command. This option allows you to specify a number of seconds to wait between each crate publishing attempt. This helps prevent hitting API rate limits on a crate registry.

This commit also includes the following changes based on your feedback:
- Moved std imports to the top of the file in `cargo-workspaces/src/publish.rs`.
- Removed tests for the `--publish-interval` feature.
- Updated README.md to document the new option.
- Updated CHANGELOG.md with details of this new feature.

The implementation includes:
- Addition of the `--publish-interval <SECONDS>` argument to the `Publish` command.
- Logic in the `Publish::run` method to pause execution for the specified interval.

Addresses #177