### PR TITLE
chore: Add release workflow to publish binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           tag: ${{ github.ref_name }}
         run: |
-          file="cargo-workspaces-${{ matrix.CARGO_BUILD_TARGET }}-$tag"
+          file="cargo-workspaces-$CARGO_BUILD_TARGET-$tag"
           cp cargo-workspaces/target/release/cargo-workspaces "$file"
           
           gh release upload "$tag" \


### PR DESCRIPTION
To the best of my ability to test this, this is a solution to the issue https://github.com/pksunkara/cargo-workspaces/issues/194

Following the existing release process (assumed) for this repository, of publishing a new version to crates.io and then creating+pushing a Git tag - the new workflow will take over from there. The workflow creates a new GitHub release and attaches binaries for Ubuntu, MacOS and Windows.

I've followed the instructions over here to test that binstall will find the uploaded assets https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md. By uploading a binary with the same naming format to a release on a repository I own. But I can't do that here.

A few outstanding questions:
- I really only need `ubuntu-latest` to work, because I want to use this on CI, but I see in your CI workflow that more platforms are tested and supported. Does it matter to create binaries for those other platforms now or should they be added if requested?
- I also see that you produce binaries under two different names `cargo-workspaces` and `cargo-ws`. Again, because my use-case is CI, I prefer having the full name and no ambiguity about what tool is being used. I totally get that a user who is using this tool manually might want less typing. So are binaries for both names wanted?

Happy to add more to this PR, but I think it does what I need. I'm thinking that adding more than that initially just slows down CI and it's maybe okay to let people open issues as they need more, but I'll leave these questions open!