### PR TITLE
Fix inverted logic from `68c7c5c`

### DIFF
--- a/cargo-workspaces/src/utils/version.rs
+++ b/cargo-workspaces/src/utils/version.rs
@@ -133,10 +133,10 @@ impl VersionOpt {
         let new_versions = self.confirm_versions(new_versions)?;
 
         for p in &metadata.packages {
-            if new_versions.contains_key(&p.name)
+            if !new_versions.contains_key(&p.name)
                 && p.dependencies
                     .iter()
-                    .all(|x| new_versions.contains_key(&x.name))
+                    .all(|x| !new_versions.contains_key(&x.name))
             {
                 continue;
             }


### PR DESCRIPTION
[68c7c5c](https://github.com/pksunkara/cargo-workspaces/commit/68c7c5cdea9d23ea1fc06829a3d47641b74db155#diff-19b0f79a9d400e60f00be959612d0e6bb4a21553d6ab295efc4ccf06b0641f5b) changed `get(<...>).is_none()` to `contains_key(...)`.
This inverts the result of the code: While the original checks whether the key is _absent_, the new version would check if the key is _present_.
This fix inverts the result of `contains_key` to restore the original behaviour.

I ran into this being an issue when updating the version of a workspace crate without any dependencies.
In this case, the crate would be skipped and the crate's `Cargo.toml` would not be updated.