### PR TITLE
Always update workspace `Cargo.toml`

### DIFF
--- a/cargo-workspaces/src/utils/version.rs
+++ b/cargo-workspaces/src/utils/version.rs
@@ -155,11 +155,13 @@ impl VersionOpt {
             )?;
         }
 
-        if let Some(new_version) = &new_version {
+        {
             let workspace_root = metadata.workspace_root.join("Cargo.toml");
             let mut new_versions = new_versions.clone();
 
-            new_versions.insert("".to_string(), new_version.clone());
+            if let Some(new_version) = &new_version {
+                new_versions.insert("".to_string(), new_version.clone());
+            }
 
             fs::write(
                 &workspace_root,


### PR DESCRIPTION
Currently, the workspace's `Cargo.toml` is only updated when at least one crate uses common versioning.
However, one can specify dependencies in `workspace.dependencies`, which is currently not updated when all packages use independent versioning.
This PR changes the behavior to always update the workspace's `Cargo.toml`, updating the versions of workspace-crates.